### PR TITLE
[codex] Complete remaining Phase 1 foundation tasks

### DIFF
--- a/docs/phase-1-architecture.md
+++ b/docs/phase-1-architecture.md
@@ -1,0 +1,80 @@
+# Phase 1 Architecture Review
+
+This document closes the remaining architectural work for Phase 1 of `Fhenix-FairMarket`.
+
+## Contract Topology
+
+```mermaid
+flowchart LR
+  Seller[Seller / Bidder] --> Proxy[FhenixFairMarketProxy]
+  Owner[Protocol Owner] --> Proxy
+  Proxy --> Core[FhenixFairMarket]
+  Core --> NFT[ERC721 Asset]
+  Core --> Adapter[ICofheAdapter / CofheAdapter]
+  Tests[Test Harness] --> Mock[MockCofhe]
+  Mock -. same typed ciphertext format .-> Adapter
+```
+
+## Roles and Responsibilities
+
+- `FhenixFairMarketProxy` preserves a stable contract address while delegating logic to the upgradeable implementation.
+- `FhenixFairMarket` owns the auction lifecycle, escrow bookkeeping, seller cancellation, owner fallback-void, and resolution recording.
+- `ICofheAdapter` is the only boundary through which the core contract should consume CoFHE-style encrypted operations.
+- `CofheAdapter` currently supplies deterministic typed ciphertext helpers for local development until production CoFHE contracts are wired in later phases.
+- `MockCofhe` mirrors the adapter surface and adds plaintext assertions for local tests.
+
+## Upgrade Path
+
+```mermaid
+sequenceDiagram
+  participant Owner
+  participant Proxy as FhenixFairMarketProxy
+  participant Impl as FhenixFairMarket
+  participant NewImpl as New Implementation
+
+  Owner->>Proxy: upgradeToAndCall(newImpl, initData)
+  Proxy->>Impl: delegatecall _authorizeUpgrade(newImpl)
+  Impl-->>Proxy: onlyOwner approval
+  Proxy->>NewImpl: delegatecall initData
+  NewImpl-->>Proxy: upgraded logic active
+```
+
+### UUPS Security Notes
+
+- Initialization replaces constructor logic and locks ownership at deployment time.
+- `_authorizeUpgrade()` is owner-gated.
+- The proxy remains thin and uses `ERC1967Proxy`, keeping upgrade logic inside the implementation where it can be audited with the contract code.
+- The test suite validates both successful owner-driven upgrades and unauthorized upgrade rejections.
+
+## Auction State Machine
+
+```mermaid
+stateDiagram-v2
+  [*] --> CREATED
+  CREATED --> ACTIVE: createAuction + NFT escrowed
+  ACTIVE --> RESOLVING: triggerFinalize after endTime
+  ACTIVE --> CANCELLED: cancelAuction before endTime
+  RESOLVING --> FINALIZED: submitResolution
+  RESOLVING --> VOIDED: triggerFallbackVoid
+```
+
+## Encrypted Boundary
+
+- Phase 1 deliberately avoids direct imports from production FHE contracts inside the market core.
+- Typed ciphertext handles currently cover:
+  - `euint32`
+  - `ebool`
+- Supported deterministic helper operations in the local adapter/mock path:
+  - `asEuint32`
+  - `asEbool`
+  - `lte`
+  - `gt`
+  - `select`
+  - `verifyEncryptedBidCoverage`
+  - `seal`
+
+## Validation Artifacts
+
+- Unit tests cover initialization, UUPS authorization, auction creation, escrow locking, state transitions, cancellation, fallback-void, and adapter/mock behavior.
+- Integration tests cover end-to-end proxy deployment, auction creation, escrow funding, encrypted bid-coverage checks, and owner resolution submission.
+- Coverage remains above the Phase 1 target (`>= 70%` branch coverage).

--- a/package.json
+++ b/package.json
@@ -8,6 +8,8 @@
   "scripts": {
     "compile": "pnpm --filter contracts compile",
     "test": "pnpm --filter contracts test",
+    "test:unit": "pnpm --filter contracts test:unit",
+    "test:integration": "pnpm --filter contracts test:integration",
     "coverage": "pnpm --filter contracts coverage"
   }
 }

--- a/packages/contracts/README.md
+++ b/packages/contracts/README.md
@@ -9,6 +9,7 @@ This workspace contains the runnable Phase 1 scaffold for `Fhenix-FairMarket`.
 - `contracts/adapters/CofheAdapter.sol`: adapter boundary that keeps the core contract isolated from future CoFHE vendor changes
 - `contracts/mocks/*.sol`: local mock contracts used by the unit test suite
 - `deploy/*.ts`: sequential deployment scripts for adapter first, then implementation + proxy
+- [../../docs/phase-1-architecture.md](../../docs/phase-1-architecture.md): Phase 1 architecture review, upgrade notes, and state-machine diagram
 
 ## Commands
 
@@ -18,10 +19,15 @@ Run these from the repository root:
 pnpm install
 pnpm compile
 pnpm test
+pnpm test:unit
+pnpm test:integration
 pnpm coverage
 ```
 
 ## Notes
 
-- The adapter currently provides a deterministic local placeholder implementation so Phase 1 can compile and test without depending on the full CoFHE execution stack.
+- The issue text references an older package name for the CoFHE Hardhat plugin. The maintained package integrated here is `cofhe-hardhat-plugin`.
+- The CoFHE Hardhat plugin is installed and version-pinned in the workspace so later Fhenix-network phases can activate it without reworking dependencies.
+- The default Phase 1 test path stays on the deterministic local adapter/mock implementation to keep the architectural foundation stable while full network-backed CoFHE flows are deferred to later phases.
+- The adapter now models typed ciphertext handles (`euint32`, `ebool`), comparison helpers (`lte`, `gt`), conditional selection, and encrypted bid-coverage checks.
 - The core contract deliberately avoids importing FHE libraries directly. Future encrypted bid logic should continue to flow only through `ICofheAdapter`.

--- a/packages/contracts/contracts/adapters/CofheAdapter.sol
+++ b/packages/contracts/contracts/adapters/CofheAdapter.sol
@@ -2,14 +2,47 @@
 pragma solidity ^0.8.25;
 
 import "../interfaces/ICofheAdapter.sol";
+import "../utils/CofheCiphertextEncoding.sol";
 
 contract CofheAdapter is ICofheAdapter {
+    using CofheCiphertextEncoding for bytes32;
+
     function lte(bytes32 ciphertext, uint256 plaintext) external pure override returns (bool) {
-        return uint256(ciphertext) <= plaintext;
+        return ciphertext.decodeEuint32() <= plaintext;
+    }
+
+    function gt(bytes32 ciphertext, uint256 plaintext) external pure override returns (bool) {
+        return ciphertext.decodeEuint32() > plaintext;
     }
 
     function asEuint32(uint32 value) external pure override returns (bytes32) {
-        return bytes32(uint256(value));
+        return CofheCiphertextEncoding.encodeEuint32(value);
+    }
+
+    function asEbool(bool value) external pure override returns (bytes32) {
+        return CofheCiphertextEncoding.encodeEbool(value);
+    }
+
+    function select(bytes32 conditionCiphertext, bytes32 whenTrueCiphertext, bytes32 whenFalseCiphertext)
+        external
+        pure
+        override
+        returns (bytes32)
+    {
+        return conditionCiphertext.decodeEbool() ? whenTrueCiphertext : whenFalseCiphertext;
+    }
+
+    function verifyEncryptedBidCoverage(bytes32 encryptedBid, uint256 availableEscrow)
+        external
+        pure
+        override
+        returns (bool)
+    {
+        return encryptedBid.decodeEuint32() <= availableEscrow;
+    }
+
+    function ciphertextKind(bytes32 ciphertext) external pure override returns (uint8) {
+        return uint8(CofheCiphertextEncoding.kindOf(ciphertext));
     }
 
     function seal(bytes32 ciphertext, address viewer) external pure override returns (bytes32) {

--- a/packages/contracts/contracts/interfaces/ICofheAdapter.sol
+++ b/packages/contracts/contracts/interfaces/ICofheAdapter.sol
@@ -4,7 +4,20 @@ pragma solidity ^0.8.25;
 interface ICofheAdapter {
     function lte(bytes32 ciphertext, uint256 plaintext) external pure returns (bool);
 
+    function gt(bytes32 ciphertext, uint256 plaintext) external pure returns (bool);
+
     function asEuint32(uint32 value) external pure returns (bytes32);
+
+    function asEbool(bool value) external pure returns (bytes32);
+
+    function select(bytes32 conditionCiphertext, bytes32 whenTrueCiphertext, bytes32 whenFalseCiphertext)
+        external
+        pure
+        returns (bytes32);
+
+    function verifyEncryptedBidCoverage(bytes32 encryptedBid, uint256 availableEscrow) external pure returns (bool);
+
+    function ciphertextKind(bytes32 ciphertext) external pure returns (uint8);
 
     function seal(bytes32 ciphertext, address viewer) external pure returns (bytes32);
 

--- a/packages/contracts/contracts/mocks/MockCofhe.sol
+++ b/packages/contracts/contracts/mocks/MockCofhe.sol
@@ -1,24 +1,21 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.25;
 
-contract MockCofhe {
-    function lte(bytes32 ciphertext, uint256 plaintext) external pure returns (bool) {
-        return uint256(ciphertext) <= plaintext;
+import "../adapters/CofheAdapter.sol";
+import "../utils/CofheCiphertextEncoding.sol";
+
+contract MockCofhe is CofheAdapter {
+    using CofheCiphertextEncoding for bytes32;
+
+    function expectPlaintext(bytes32 ciphertext, uint256 expectedPlaintext) external pure returns (bool) {
+        return ciphertext.decodeEuint32() == expectedPlaintext;
     }
 
-    function asEuint32(uint32 value) external pure returns (bytes32) {
-        return bytes32(uint256(value));
+    function expectBoolPlaintext(bytes32 ciphertext, bool expectedPlaintext) external pure returns (bool) {
+        return ciphertext.decodeEbool() == expectedPlaintext;
     }
 
-    function seal(bytes32 ciphertext, address viewer) external pure returns (bytes32) {
-        return keccak256(abi.encodePacked(ciphertext, viewer));
-    }
-
-    function getRawCiphertext(bytes32 ciphertext) external pure returns (bytes32) {
-        return ciphertext;
-    }
-
-    function expectPlaintext(bytes32 ciphertext, uint32 expectedPlaintext) external pure returns (bool) {
-        return uint256(ciphertext) == expectedPlaintext;
+    function explainCiphertext(bytes32 ciphertext) external pure returns (uint8 kind, uint256 payload) {
+        return (uint8(CofheCiphertextEncoding.kindOf(ciphertext)), CofheCiphertextEncoding.payloadOf(ciphertext));
     }
 }

--- a/packages/contracts/contracts/utils/CofheCiphertextEncoding.sol
+++ b/packages/contracts/contracts/utils/CofheCiphertextEncoding.sol
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+library CofheCiphertextEncoding {
+    uint256 private constant _KIND_SHIFT = 248;
+    uint256 private constant _PAYLOAD_MASK = type(uint248).max;
+
+    enum CiphertextKind {
+        UNKNOWN,
+        EUINT32,
+        EBOOL
+    }
+
+    error InvalidCiphertextKind(uint8 expected, uint8 actual);
+
+    function encodeEuint32(uint32 value) internal pure returns (bytes32) {
+        return bytes32((uint256(uint8(CiphertextKind.EUINT32)) << _KIND_SHIFT) | uint256(value));
+    }
+
+    function encodeEbool(bool value) internal pure returns (bytes32) {
+        return bytes32((uint256(uint8(CiphertextKind.EBOOL)) << _KIND_SHIFT) | (value ? 1 : 0));
+    }
+
+    function decodeEuint32(bytes32 ciphertext) internal pure returns (uint32) {
+        _requireKind(ciphertext, CiphertextKind.EUINT32);
+        return uint32(payloadOf(ciphertext));
+    }
+
+    function decodeEbool(bytes32 ciphertext) internal pure returns (bool) {
+        _requireKind(ciphertext, CiphertextKind.EBOOL);
+        return payloadOf(ciphertext) != 0;
+    }
+
+    function kindOf(bytes32 ciphertext) internal pure returns (CiphertextKind) {
+        uint8 kind = uint8(uint256(ciphertext) >> _KIND_SHIFT);
+
+        if (kind > uint8(CiphertextKind.EBOOL)) {
+            return CiphertextKind.UNKNOWN;
+        }
+
+        return CiphertextKind(kind);
+    }
+
+    function payloadOf(bytes32 ciphertext) internal pure returns (uint256) {
+        return uint256(ciphertext) & _PAYLOAD_MASK;
+    }
+
+    function _requireKind(bytes32 ciphertext, CiphertextKind expectedKind) private pure {
+        CiphertextKind actualKind = kindOf(ciphertext);
+        if (actualKind != expectedKind) {
+            revert InvalidCiphertextKind(uint8(expectedKind), uint8(actualKind));
+        }
+    }
+}

--- a/packages/contracts/hardhat.config.ts
+++ b/packages/contracts/hardhat.config.ts
@@ -38,7 +38,7 @@ const config: HardhatUserConfig = {
   },
   paths: {
     sources: "./contracts",
-    tests: "./test/unit",
+    tests: "./test",
     cache: "./cache",
     artifacts: "./artifacts"
   },

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -8,15 +8,21 @@
   "scripts": {
     "compile": "hardhat compile",
     "test": "hardhat test",
+    "test:unit": "hardhat test test/unit",
+    "test:integration": "hardhat test test/integration",
     "coverage": "hardhat coverage",
     "deploy:adapter": "hardhat run deploy/00_deploy_adapters.ts",
     "deploy:core": "hardhat run deploy/01_deploy_core_proxy.ts"
   },
   "devDependencies": {
+    "@fhenixprotocol/cofhe-contracts": "^0.0.13",
+    "@fhenixprotocol/cofhe-mock-contracts": "^0.3.1",
     "@nomicfoundation/hardhat-toolbox": "^5.0.0",
     "@openzeppelin/contracts": "^5.0.2",
     "@openzeppelin/contracts-upgradeable": "^5.0.2",
     "@types/node": "^22.10.1",
+    "cofhe-hardhat-plugin": "^0.3.1",
+    "cofhejs": "^0.3.1",
     "dotenv": "^16.4.7",
     "ethers": "^6.14.0",
     "hardhat": "^2.22.0",

--- a/packages/contracts/test/integration/Phase1Workflow.test.ts
+++ b/packages/contracts/test/integration/Phase1Workflow.test.ts
@@ -1,0 +1,81 @@
+import { loadFixture, time } from "@nomicfoundation/hardhat-network-helpers";
+import { expect } from "chai";
+import { ethers } from "hardhat";
+
+describe("Phase 1 integration workflow", function () {
+  async function deployFixture() {
+    const [owner, seller, bidder] = await ethers.getSigners();
+
+    const adapterFactory = await ethers.getContractFactory("CofheAdapter");
+    const adapter = await adapterFactory.deploy();
+    await adapter.waitForDeployment();
+
+    const implementationFactory = await ethers.getContractFactory("FhenixFairMarket");
+    const implementation = await implementationFactory.deploy();
+    await implementation.waitForDeployment();
+
+    const proxyFactory = await ethers.getContractFactory("FhenixFairMarketProxy");
+    const initData = implementationFactory.interface.encodeFunctionData("initialize", [
+      await adapter.getAddress(),
+      owner.address,
+      ethers.ZeroAddress
+    ]);
+
+    const proxy = await proxyFactory.deploy(await implementation.getAddress(), initData);
+    await proxy.waitForDeployment();
+
+    const market = implementationFactory.attach(await proxy.getAddress());
+
+    const nftFactory = await ethers.getContractFactory("MockERC721");
+    const nft = await nftFactory.deploy();
+    await nft.waitForDeployment();
+
+    const mockCofheFactory = await ethers.getContractFactory("MockCofhe");
+    const mockCofhe = await mockCofheFactory.deploy();
+    await mockCofhe.waitForDeployment();
+
+    return {
+      owner,
+      seller,
+      bidder,
+      adapter,
+      market,
+      nft,
+      mockCofhe
+    };
+  }
+
+  it("executes the Phase 1 scaffold from escrow to encrypted resolution", async function () {
+    const { owner, seller, bidder, adapter, market, nft, mockCofhe } = await loadFixture(deployFixture);
+
+    await nft.connect(seller).mint(seller.address);
+    await nft.connect(seller).approve(await market.getAddress(), 1n);
+
+    await market.connect(seller).createAuction(await nft.getAddress(), 1n, 24 * 60 * 60, 1_000n, true, {
+      value: 1_000n
+    });
+
+    await market.connect(bidder).lockEscrow(1n, { value: 600n });
+    expect(await market.escrowBalances(1n, bidder.address)).to.equal(600n);
+
+    const encryptedWinningBid = await adapter.asEuint32(450);
+    expect(await adapter.verifyEncryptedBidCoverage(encryptedWinningBid, 600n)).to.equal(true);
+
+    const encryptedWinner = await adapter.select(
+      await adapter.asEbool(true),
+      encryptedWinningBid,
+      await adapter.asEuint32(300)
+    );
+    expect(await mockCofhe.expectPlaintext(encryptedWinner, 450)).to.equal(true);
+
+    await time.increase(24 * 60 * 60 + 1);
+    await market.triggerFinalize(1n);
+    await market.connect(owner).submitResolution(1n, encryptedWinner, 450n);
+
+    const auction = await market.getAuction(1n);
+    expect(auction[5]).to.equal(3n);
+    expect(auction[8]).to.equal(encryptedWinner);
+    expect(auction[9]).to.equal(450n);
+    expect(await nft.ownerOf(1n)).to.equal(await market.getAddress());
+  });
+});

--- a/packages/contracts/test/unit/EscrowLogic.test.ts
+++ b/packages/contracts/test/unit/EscrowLogic.test.ts
@@ -327,13 +327,47 @@ describe("FhenixFairMarket Phase 1", function () {
     const { adapter, mockCofhe } = await loadFixture(deployFixture);
 
     const ciphertext = await adapter.asEuint32(42);
+    const encryptedTrue = await adapter.asEbool(true);
+    const encryptedFalse = await adapter.asEbool(false);
+    const selectedCiphertext = await adapter.select(encryptedTrue, ciphertext, await adapter.asEuint32(7));
+
     expect(await adapter.lte(ciphertext, 100)).to.equal(true);
+    expect(await adapter.gt(ciphertext, 40)).to.equal(true);
+    expect(await adapter.verifyEncryptedBidCoverage(ciphertext, 42)).to.equal(true);
+    expect(await adapter.verifyEncryptedBidCoverage(ciphertext, 41)).to.equal(false);
+    expect(await adapter.ciphertextKind(ciphertext)).to.equal(1);
+    expect(await adapter.ciphertextKind(encryptedTrue)).to.equal(2);
+    expect(await adapter.select(encryptedFalse, ciphertext, await adapter.asEuint32(7))).to.equal(
+      await adapter.asEuint32(7)
+    );
     expect(await adapter.seal(ciphertext, ethers.ZeroAddress)).to.not.equal(ethers.ZeroHash);
     expect(await adapter.getRawCiphertext(ciphertext)).to.equal(ciphertext);
     expect(await mockCofhe.asEuint32(42)).to.equal(ciphertext);
     expect(await mockCofhe.lte(ciphertext, 100)).to.equal(true);
+    expect(await mockCofhe.gt(ciphertext, 40)).to.equal(true);
     expect(await mockCofhe.seal(ciphertext, ethers.ZeroAddress)).to.not.equal(ethers.ZeroHash);
     expect(await mockCofhe.getRawCiphertext(ciphertext)).to.equal(ciphertext);
     expect(await mockCofhe.expectPlaintext(ciphertext, 42)).to.equal(true);
+    expect(await mockCofhe.expectBoolPlaintext(encryptedTrue, true)).to.equal(true);
+    expect(await mockCofhe.expectBoolPlaintext(encryptedFalse, false)).to.equal(true);
+    expect(await mockCofhe.expectPlaintext(selectedCiphertext, 42)).to.equal(true);
+
+    const explanation = await mockCofhe.explainCiphertext(ciphertext);
+    expect(explanation[0]).to.equal(1n);
+    expect(explanation[1]).to.equal(42n);
+  });
+
+  it("keeps ciphertext type tags explicit across the local adapter and mock path", async function () {
+    const { adapter, mockCofhe } = await loadFixture(deployFixture);
+
+    const encryptedBid = await adapter.asEuint32(17);
+    const encryptedCondition = await adapter.asEbool(true);
+
+    expect(await adapter.ciphertextKind(encryptedBid)).to.equal(1);
+    expect(await adapter.ciphertextKind(encryptedCondition)).to.equal(2);
+
+    const bidExplanation = await mockCofhe.explainCiphertext(encryptedBid);
+    expect(bidExplanation[0]).to.equal(1n);
+    expect(bidExplanation[1]).to.equal(17n);
   });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,6 +10,12 @@ importers:
 
   packages/contracts:
     devDependencies:
+      '@fhenixprotocol/cofhe-contracts':
+        specifier: ^0.0.13
+        version: 0.0.13
+      '@fhenixprotocol/cofhe-mock-contracts':
+        specifier: ^0.3.1
+        version: 0.3.1(@fhenixprotocol/cofhe-contracts@0.0.13)(@openzeppelin/contracts-upgradeable@5.6.1(@openzeppelin/contracts@5.6.1))(@openzeppelin/contracts@5.6.1)
       '@nomicfoundation/hardhat-toolbox':
         specifier: ^5.0.0
         version: 5.0.0(hmdm5oo6xyx5qnxvbdlhx6hhwq)
@@ -22,6 +28,12 @@ importers:
       '@types/node':
         specifier: ^22.10.1
         version: 22.19.17
+      cofhe-hardhat-plugin:
+        specifier: ^0.3.1
+        version: 0.3.1(@nomicfoundation/hardhat-ethers@3.1.3(ethers@6.16.0)(hardhat@2.28.6(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.9.3))(typescript@5.9.3)))(cofhejs@0.3.1)(ethers@6.16.0)(hardhat@2.28.6(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.9.3))(typescript@5.9.3))
+      cofhejs:
+        specifier: ^0.3.1
+        version: 0.3.1
       dotenv:
         specifier: ^16.4.7
         version: 16.6.1
@@ -167,6 +179,16 @@ packages:
   '@fastify/busboy@2.1.1':
     resolution: {integrity: sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==}
     engines: {node: '>=14'}
+
+  '@fhenixprotocol/cofhe-contracts@0.0.13':
+    resolution: {integrity: sha512-+lHo5v52fR7QfQj2ottDw4F/AqZg6obPBRqvK576SJatX3o4aH6ZSt2kxNb5kT8Ckthjw6FoNmLdUVCDpP400w==}
+
+  '@fhenixprotocol/cofhe-mock-contracts@0.3.1':
+    resolution: {integrity: sha512-a2Fi9e6emgoPwO/vMhN9m/QXHl7ypQP1YixlJaLkAX80vtm2rAM77O7xcslCzH7R9NNHGJxiME+comrpNjII5g==}
+    peerDependencies:
+      '@fhenixprotocol/cofhe-contracts': 0.0.13
+      '@openzeppelin/contracts': ^5.0.0
+      '@openzeppelin/contracts-upgradeable': ^5.0.0
 
   '@jridgewell/resolve-uri@3.1.2':
     resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
@@ -468,6 +490,9 @@ packages:
   '@types/node@10.17.60':
     resolution: {integrity: sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw==}
 
+  '@types/node@20.19.39':
+    resolution: {integrity: sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==}
+
   '@types/node@22.19.17':
     resolution: {integrity: sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==}
 
@@ -763,6 +788,18 @@ packages:
 
   cliui@7.0.4:
     resolution: {integrity: sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==}
+
+  cofhe-hardhat-plugin@0.3.1:
+    resolution: {integrity: sha512-1SMVZrpclGI1qDrVT7NKAKQfbcvB4fXSvJjcWyerh4yVStENakI3D1N0c3BNQG4PEtlw84US7ug3rjMtv5qstg==}
+    peerDependencies:
+      '@nomicfoundation/hardhat-ethers': ^3.0.5
+      cofhejs: ^0.3.0
+      ethers: ^6.10.0
+      hardhat: ^2.11.0
+
+  cofhejs@0.3.1:
+    resolution: {integrity: sha512-yswOoHWxSpvI1ruvBEDmxzf04GCj0p0CVehS2I3YJBuPCWI11FxAvJ0pD/gRzc/ZN59qa2qlf++fq0k/PV0PlA==}
+    engines: {node: '>=20.0.0'}
 
   color-convert@1.9.3:
     resolution: {integrity: sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==}
@@ -1234,12 +1271,18 @@ packages:
     resolution: {integrity: sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==}
     engines: {node: '>=0.10.0'}
 
+  idb-keyval@6.2.2:
+    resolution: {integrity: sha512-yjD9nARJ/jb1g+CvD0tlhUHOrJ9Sy0P8T9MF3YaLlHnSRpwPfpTX0XIvpmw3gAJUmEu3FiICLBDPXVwyEvrleg==}
+
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
     engines: {node: '>= 4'}
 
   immer@10.0.2:
     resolution: {integrity: sha512-Rx3CqeqQ19sxUtYV9CU911Vhy8/721wRFnJv3REVGWUmoAcIwzifTsdmJte/MV+0/XpM35LZdQMBGkRIoLPwQA==}
+
+  immer@10.2.0:
+    resolution: {integrity: sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==}
 
   immutable@4.3.8:
     resolution: {integrity: sha512-d/Ld9aLbKpNwyl0KiM2CT1WYvkitQ1TSvmRtkcV8FKStiDoA7Slzgjmb/1G2yhKM1p0XeNOieaTbFZmU1d3Xuw==}
@@ -1508,6 +1551,9 @@ packages:
   node-gyp-build@4.8.4:
     resolution: {integrity: sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==}
     hasBin: true
+
+  node-tfhe@0.11.1:
+    resolution: {integrity: sha512-QFkIeIZ5IbdvhpkzImwakL2+sZFCTXCwGvOacE1NczR+zgrg5ixHU9KpjuuIi1YbbKFGJEMoSUmivDktuzFaKg==}
 
   nofilter@3.1.0:
     resolution: {integrity: sha512-l2NNj07e9afPnhAhvgVrCD/oy2Ai1yfLpuo3EpiO1jFTsB4sFz6oIfAfSZyQzVpkZQ9xS8ZS5g1jCBgq4Hwo0g==}
@@ -1906,6 +1952,9 @@ packages:
     resolution: {integrity: sha512-9kY+CygyYM6j02t5YFHbNz2FN5QmYGv9zAjVp4lCDjlCw7amdckXlEt/bjMhUIfj4ThGRE4gCUH5+yGnNuPo5A==}
     engines: {node: '>=10.0.0'}
 
+  tfhe@0.11.1:
+    resolution: {integrity: sha512-D4YeL0DYz4IOV/X7YzKFexkjbJdOdGn2M7mfDNOQW1OxA+NO/Z61BJ6ULLTvdBEQ3N6P985lNO61Drgsjf0g/w==}
+
   then-request@6.0.2:
     resolution: {integrity: sha512-3ZBiG7JvP3wbDzA9iNY5zJQcHL4jn/0BWtXIkagfz7QgOL/LqjCEOBQuJNZfu0XYnv5JhKh+cDxCPM4ILrqruA==}
     engines: {node: '>=6.0.0'}
@@ -1965,6 +2014,12 @@ packages:
   tsort@0.0.1:
     resolution: {integrity: sha512-Tyrf5mxF8Ofs1tNoxA13lFeZ2Zrbd6cKbuH3V+MQ5sb6DtBj5FjrXVsRWT8YvNAQTqNoz66dz1WsbigI22aEnw==}
 
+  tweetnacl-util@0.15.1:
+    resolution: {integrity: sha512-RKJBIj8lySrShN4w6i/BonWp2Z/uxwC3h4y7xsRrpP59ZboCd0GpEVsOnMDYLMmKBpYhb5TgHzZXy7wTfYFBRw==}
+
+  tweetnacl@1.0.3:
+    resolution: {integrity: sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw==}
+
   type-check@0.3.2:
     resolution: {integrity: sha512-ZCmOJdvOWDBYJlzAoFkC+Q0+bUyEOS1ltgp1MGU03fqHG+dbi9tBFU2Rd9QKiDZFAYrhPh2JUf7rZRIuHRKtOg==}
     engines: {node: '>= 0.8.0'}
@@ -1984,6 +2039,10 @@ packages:
   type-fest@0.7.1:
     resolution: {integrity: sha512-Ne2YiiGN8bmrmJJEuTWTLJR32nh/JdL1+PSicowtNb0WFpn59GK8/lfD61bVtzguz7b3PBt74nxpv/Pw5po5Rg==}
     engines: {node: '>=8'}
+
+  type-fest@4.41.0:
+    resolution: {integrity: sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==}
+    engines: {node: '>=16'}
 
   typechain@8.3.2:
     resolution: {integrity: sha512-x/sQYr5w9K7yv3es7jo4KTX05CLxOf7TRWwoHlrjRh8H82G64g+k7VuWPJlgMo6qrjfCulOdfBjiaDtmhFYD/Q==}
@@ -2147,6 +2206,27 @@ packages:
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
+
+  zod@3.25.76:
+    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
+
+  zustand@5.0.12:
+    resolution: {integrity: sha512-i77ae3aZq4dhMlRhJVCYgMLKuSiZAaUPAct2AksxQ+gOtimhGMdXljRT21P5BNpeT4kXlLIckvkPM029OljD7g==}
+    engines: {node: '>=12.20.0'}
+    peerDependencies:
+      '@types/react': '>=18.0.0'
+      immer: '>=9.0.6'
+      react: '>=18.0.0'
+      use-sync-external-store: '>=1.2.0'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      immer:
+        optional: true
+      react:
+        optional: true
+      use-sync-external-store:
+        optional: true
 
 snapshots:
 
@@ -2435,6 +2515,16 @@ snapshots:
       '@ethersproject/strings': 5.8.0
 
   '@fastify/busboy@2.1.1': {}
+
+  '@fhenixprotocol/cofhe-contracts@0.0.13':
+    dependencies:
+      '@openzeppelin/contracts': 5.6.1
+
+  '@fhenixprotocol/cofhe-mock-contracts@0.3.1(@fhenixprotocol/cofhe-contracts@0.0.13)(@openzeppelin/contracts-upgradeable@5.6.1(@openzeppelin/contracts@5.6.1))(@openzeppelin/contracts@5.6.1)':
+    dependencies:
+      '@fhenixprotocol/cofhe-contracts': 0.0.13
+      '@openzeppelin/contracts': 5.6.1
+      '@openzeppelin/contracts-upgradeable': 5.6.1(@openzeppelin/contracts@5.6.1)
 
   '@jridgewell/resolve-uri@3.1.2': {}
 
@@ -2781,6 +2871,10 @@ snapshots:
 
   '@types/node@10.17.60': {}
 
+  '@types/node@20.19.39':
+    dependencies:
+      undici-types: 6.21.0
+
   '@types/node@22.19.17':
     dependencies:
       undici-types: 6.21.0
@@ -3085,6 +3179,39 @@ snapshots:
       string-width: 4.2.3
       strip-ansi: 6.0.1
       wrap-ansi: 7.0.0
+
+  cofhe-hardhat-plugin@0.3.1(@nomicfoundation/hardhat-ethers@3.1.3(ethers@6.16.0)(hardhat@2.28.6(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.9.3))(typescript@5.9.3)))(cofhejs@0.3.1)(ethers@6.16.0)(hardhat@2.28.6(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.9.3))(typescript@5.9.3)):
+    dependencies:
+      '@fhenixprotocol/cofhe-contracts': 0.0.13
+      '@fhenixprotocol/cofhe-mock-contracts': 0.3.1(@fhenixprotocol/cofhe-contracts@0.0.13)(@openzeppelin/contracts-upgradeable@5.6.1(@openzeppelin/contracts@5.6.1))(@openzeppelin/contracts@5.6.1)
+      '@nomicfoundation/hardhat-ethers': 3.1.3(ethers@6.16.0)(hardhat@2.28.6(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.9.3))(typescript@5.9.3))
+      '@openzeppelin/contracts': 5.6.1
+      '@openzeppelin/contracts-upgradeable': 5.6.1(@openzeppelin/contracts@5.6.1)
+      axios: 1.15.2
+      chalk: 4.1.2
+      cofhejs: 0.3.1
+      ethers: 6.16.0
+      fast-glob: 3.3.3
+      hardhat: 2.28.6(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.9.3))(typescript@5.9.3)
+    transitivePeerDependencies:
+      - debug
+
+  cofhejs@0.3.1:
+    dependencies:
+      '@types/node': 20.19.39
+      idb-keyval: 6.2.2
+      immer: 10.2.0
+      node-tfhe: 0.11.1
+      tfhe: 0.11.1
+      tweetnacl: 1.0.3
+      tweetnacl-util: 0.15.1
+      type-fest: 4.41.0
+      zod: 3.25.76
+      zustand: 5.0.12(immer@10.2.0)
+    transitivePeerDependencies:
+      - '@types/react'
+      - react
+      - use-sync-external-store
 
   color-convert@1.9.3:
     dependencies:
@@ -3716,9 +3843,13 @@ snapshots:
     dependencies:
       safer-buffer: 2.1.2
 
+  idb-keyval@6.2.2: {}
+
   ignore@5.3.2: {}
 
   immer@10.0.2: {}
+
+  immer@10.2.0: {}
 
   immutable@4.3.8: {}
 
@@ -3961,6 +4092,8 @@ snapshots:
       lodash: 4.18.1
 
   node-gyp-build@4.8.4: {}
+
+  node-tfhe@0.11.1: {}
 
   nofilter@3.1.0: {}
 
@@ -4395,6 +4528,8 @@ snapshots:
       string-width: 4.2.3
       strip-ansi: 6.0.1
 
+  tfhe@0.11.1: {}
+
   then-request@6.0.2:
     dependencies:
       '@types/concat-stream': 1.6.1
@@ -4469,6 +4604,10 @@ snapshots:
 
   tsort@0.0.1: {}
 
+  tweetnacl-util@0.15.1: {}
+
+  tweetnacl@1.0.3: {}
+
   type-check@0.3.2:
     dependencies:
       prelude-ls: 1.1.2
@@ -4480,6 +4619,8 @@ snapshots:
   type-fest@0.21.3: {}
 
   type-fest@0.7.1: {}
+
+  type-fest@4.41.0: {}
 
   typechain@8.3.2(typescript@5.9.3):
     dependencies:
@@ -4614,3 +4755,9 @@ snapshots:
   yn@3.1.1: {}
 
   yocto-queue@0.1.0: {}
+
+  zod@3.25.76: {}
+
+  zustand@5.0.12(immer@10.2.0):
+    optionalDependencies:
+      immer: 10.2.0


### PR DESCRIPTION
﻿## Summary
- complete the remaining Phase 1 foundation work for environment setup, typed CoFHE adapter semantics, richer local mocks, and architecture documentation
- add an integration test that drives the proxy-based auction flow from escrow funding through encrypted resolution submission
- keep the core contract isolated from direct FHE imports while pinning the current CoFHE Hardhat plugin dependencies for later network-backed phases

## Validation
- `C:\Users\Ahmed\AppData\Local\Programs\node-v22.22.2-win-x64\node.exe --version`
- `$env:Path='C:\Users\Ahmed\AppData\Local\Programs\node-v22.22.2-win-x64;' + $env:Path; pnpm.cmd compile`
- `$env:Path='C:\Users\Ahmed\AppData\Local\Programs\node-v22.22.2-win-x64;' + $env:Path; pnpm.cmd test`
- `$env:Path='C:\Users\Ahmed\AppData\Local\Programs\node-v22.22.2-win-x64;' + $env:Path; pnpm.cmd coverage`

## Notes
- the historical issue text references an older CoFHE Hardhat plugin package name; the maintained package available on npm is `cofhe-hardhat-plugin`
- the default Phase 1 runtime stays on the deterministic local adapter/mock path, while the plugin dependencies are now pinned in the workspace for later network integration phases

Closes #1
Closes #7
Closes #12
Closes #13
Closes #14
Closes #15
Closes #16
Closes #17
