### PR TITLE
[codex] Implement Phase 2 encrypted settlement flows

### DIFF
--- a/.github/workflows/project-board-automation.yml
+++ b/.github/workflows/project-board-automation.yml
@@ -71,6 +71,15 @@ jobs:
               return BACKLOG_STATUS;
             }
 
+            function isProjectAccessDenied(error) {
+              const message = String(error?.message || "");
+              if (message.includes("Resource not accessible by integration")) {
+                return true;
+              }
+
+              return (error?.errors || []).some((entry) => entry?.type === "FORBIDDEN");
+            }
+
             async function getStatusField() {
               const query = `query($projectId: ID!) {
                 node(id: $projectId) {
@@ -158,37 +167,48 @@ jobs:
               return result.addProjectV2ItemById.item.id;
             }
 
-            const targetStatusName = resolveTargetStatus();
-            const statusField = await getStatusField();
+            try {
+              const targetStatusName = resolveTargetStatus();
+              const statusField = await getStatusField();
 
-            if (!statusField) {
-              core.warning(`Project field "${STATUS_FIELD_NAME}" (${STATUS_FIELD_ID}) was not found.`);
-              return;
-            }
-
-            const targetOption = statusField.options.find((entry) => entry.name === targetStatusName);
-            if (!targetOption) {
-              core.warning(`Target status "${targetStatusName}" was not found in the project field options.`);
-              return;
-            }
-
-            const itemId = await getOrCreateProjectItemId(item.node_id);
-            const mutation = `mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $optionId: String!) {
-              updateProjectV2ItemFieldValue(input: {
-                projectId: $projectId,
-                itemId: $itemId,
-                fieldId: $fieldId,
-                value: { singleSelectOptionId: $optionId }
-              }) {
-                clientMutationId
+              if (!statusField) {
+                core.warning(`Project field "${STATUS_FIELD_NAME}" (${STATUS_FIELD_ID}) was not found.`);
+                return;
               }
-            }`;
 
-            await github.graphql(mutation, {
-              projectId: PROJECT_ID,
-              itemId,
-              fieldId: statusField.id,
-              optionId: targetOption.id
-            });
+              const targetOption = statusField.options.find((entry) => entry.name === targetStatusName);
+              if (!targetOption) {
+                core.warning(`Target status "${targetStatusName}" was not found in the project field options.`);
+                return;
+              }
 
-            console.log(`Moved #${item.number} to "${targetStatusName}"`);
+              const itemId = await getOrCreateProjectItemId(item.node_id);
+              const mutation = `mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $optionId: String!) {
+                updateProjectV2ItemFieldValue(input: {
+                  projectId: $projectId,
+                  itemId: $itemId,
+                  fieldId: $fieldId,
+                  value: { singleSelectOptionId: $optionId }
+                }) {
+                  clientMutationId
+                }
+              }`;
+
+              await github.graphql(mutation, {
+                projectId: PROJECT_ID,
+                itemId,
+                fieldId: statusField.id,
+                optionId: targetOption.id
+              });
+
+              console.log(`Moved #${item.number} to "${targetStatusName}"`);
+            } catch (error) {
+              if (isProjectAccessDenied(error)) {
+                core.warning(
+                  `Skipping project sync for #${item.number}: the workflow token cannot access ProjectV2 in this run context.`
+                );
+                return;
+              }
+
+              throw error;
+            }

--- a/docs/phase-2-security-settlement.md
+++ b/docs/phase-2-security-settlement.md
@@ -1,0 +1,57 @@
+# Phase 2: Security & Settlement
+
+This phase upgrades the market from a documentation-first escrow flow into a settlement-aware auction core.
+
+## What changed
+
+- `placeBid()` now stores encrypted bid handles in `O(1)` and rejects bids that exceed the caller's escrow via `ICofheAdapter.lte(...)`.
+- `claimRefund()` follows a strict pull-over-push model. Each participant withdraws their own refund, and there are no payout loops in the market contract.
+- `SettlementEngine.sol` centralizes dynamic timeout, seller slashing, seller payout, and pro-rata compensation math.
+- `SlashedPot.sol` receives seller penalties on `CANCELLED` and `VOIDED` paths, then releases compensation per bidder on demand.
+- `triggerFallbackVoid()` now enforces a moving timeout window instead of an immediate owner-only void. Long idle auction periods are excluded from the network average so normal auction duration does not inflate the emergency threshold.
+- Final settlement became two-step and explicit:
+  - seller claims proceeds with `claimSellerProceeds()`
+  - winner claims the locked NFT with `claimAsset()`
+
+## Architectural flow
+
+```mermaid
+flowchart TD
+  A[lockEscrow] --> B[placeBid]
+  B --> C[triggerFinalize]
+  C --> D[submitResolution]
+  D --> E[claimRefund winner/losers]
+  D --> F[claimSellerProceeds]
+  D --> G[claimAsset]
+```
+
+## Cancellation and fallback flow
+
+```mermaid
+flowchart TD
+  A[ACTIVE auction] --> B[cancelAuction by seller]
+  A --> C[triggerFinalize]
+  C --> D[dynamic timeout exceeded]
+  D --> E[triggerFallbackVoid]
+  B --> F[register slash in SlashedPot]
+  E --> F
+  F --> G[claimRefund per bidder]
+  B --> H[claimSellerProceeds for unslashed remainder]
+  E --> H
+```
+
+## Audit-oriented invariants
+
+- No `for` or `while` loops in refund or compensation paths.
+- Plain bid amounts are not emitted in bid or resolution events.
+- Seller penalties are escrow-backed and never mint synthetic compensation.
+- Fallback only opens after a dynamic threshold derived from observed short-interval network activity.
+- NFT custody remains locked in escrow until one of these terminal outcomes:
+  - returned to seller on `CANCELLED`
+  - returned to seller on `VOIDED`
+  - claimed by winner or seller after `FINALIZED`
+
+## Validation
+
+- `AsyncResolution.test.ts` covers encrypted solvency, pull-based refunds, seller proceeds, and slashed-pot compensation.
+- `DynamicTimeout.test.ts` covers a 30-minute sequencer outage and a congested network profile with a higher timeout ceiling.

--- a/packages/contracts/README.md
+++ b/packages/contracts/README.md
@@ -1,15 +1,19 @@
 # Contracts Workspace
 
-This workspace contains the runnable Phase 1 scaffold for `Fhenix-FairMarket`.
+This workspace contains the runnable Phase 1 and Phase 2 contract foundation for `Fhenix-FairMarket`.
 
-## Included in Phase 1
+## Included in the current scope
 
-- `contracts/core/FhenixFairMarket.sol`: upgradeable auction foundation with `initialize`, `createAuction`, `lockEscrow`, and guarded state transitions
+- `contracts/core/FhenixFairMarket.sol`: upgradeable auction core with escrow locking, encrypted bid placement, guarded state transitions, refunds, seller settlement, and fallback logic
 - `contracts/core/FhenixFairMarketProxy.sol`: thin `ERC1967Proxy` wrapper for UUPS deployments
 - `contracts/adapters/CofheAdapter.sol`: adapter boundary that keeps the core contract isolated from future CoFHE vendor changes
+- `contracts/adapters/NFTGuard.sol`: escrow helper for NFT custody and terminal asset release
+- `contracts/settlement/SettlementEngine.sol`: centralized math for dynamic timeout, refunds, slashing, and seller payouts
+- `contracts/settlement/SlashedPot.sol`: pull-based compensation pot for cancelled or voided auctions
 - `contracts/mocks/*.sol`: local mock contracts used by the unit test suite
-- `deploy/*.ts`: sequential deployment scripts for adapter first, then implementation + proxy
+- `deploy/*.ts`: sequential deployment scripts for adapter/engine first, then proxy + slashed-pot wiring
 - [../../docs/phase-1-architecture.md](../../docs/phase-1-architecture.md): Phase 1 architecture review, upgrade notes, and state-machine diagram
+- [../../docs/phase-2-security-settlement.md](../../docs/phase-2-security-settlement.md): Phase 2 settlement, refund, slashing, and dynamic-timeout overview
 
 ## Commands
 
@@ -30,4 +34,5 @@ pnpm coverage
 - The CoFHE Hardhat plugin is installed and version-pinned in the workspace so later Fhenix-network phases can activate it without reworking dependencies.
 - The default Phase 1 test path stays on the deterministic local adapter/mock implementation to keep the architectural foundation stable while full network-backed CoFHE flows are deferred to later phases.
 - The adapter now models typed ciphertext handles (`euint32`, `ebool`), comparison helpers (`lte`, `gt`), conditional selection, and encrypted bid-coverage checks.
-- The core contract deliberately avoids importing FHE libraries directly. Future encrypted bid logic should continue to flow only through `ICofheAdapter`.
+- The Phase 2 refund path is strictly pull-based. Compensation is computed per claimant and no payout loops are used in the core market contract.
+- The core contract deliberately avoids importing FHE libraries directly. Encrypted bid logic should continue to flow only through `ICofheAdapter`.

--- a/packages/contracts/contracts/adapters/NFTGuard.sol
+++ b/packages/contracts/contracts/adapters/NFTGuard.sol
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+import "@openzeppelin/contracts/token/ERC721/IERC721.sol";
+
+library NFTGuard {
+    function lockIntoEscrow(address nftContract, address owner, address escrow, uint256 tokenId) internal {
+        IERC721(nftContract).safeTransferFrom(owner, escrow, tokenId);
+    }
+
+    function releaseFromEscrow(address nftContract, address escrow, address recipient, uint256 tokenId) internal {
+        IERC721(nftContract).safeTransferFrom(escrow, recipient, tokenId);
+    }
+}

--- a/packages/contracts/contracts/core/FhenixFairMarket.sol
+++ b/packages/contracts/contracts/core/FhenixFairMarket.sol
@@ -7,7 +7,10 @@ import "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 import "@openzeppelin/contracts/token/ERC721/IERC721.sol";
 import "@openzeppelin/contracts/token/ERC721/IERC721Receiver.sol";
 
+import "../adapters/NFTGuard.sol";
 import "../interfaces/ICofheAdapter.sol";
+import "../interfaces/ISettlementEngine.sol";
+import "../interfaces/ISlashedPot.sol";
 
 contract FhenixFairMarket is
     Initializable,
@@ -36,6 +39,14 @@ contract FhenixFairMarket is
         uint64 lastBlockTimestamp;
         bytes32 winnerCiphertext;
         uint256 winningAmount;
+        address winner;
+        uint256 totalEscrow;
+        uint256 slashAmount;
+        uint64 createdAt;
+        uint64 resolvingSince;
+        bool sellerClaimed;
+        bool assetClaimed;
+        uint32 bidCount;
     }
 
     error AuctionDoesNotExist(uint256 auctionId);
@@ -44,27 +55,44 @@ contract FhenixFairMarket is
     error IncorrectSellerDeposit(uint256 expected, uint256 actual);
     error InvalidDuration(uint256 providedDuration);
     error InvalidStateTransition(AuctionState fromState, AuctionState toState);
+    error AssetAlreadyClaimed(uint256 auctionId);
+    error BidExceedsEscrow(uint256 auctionId, address bidder);
+    error FallbackThresholdNotReached(uint256 elapsed, uint256 requiredThreshold);
+    error InvalidWinningAmount(uint256 auctionId, uint256 winningAmount, uint256 availableEscrow);
+    error MissingEncryptedBid(uint256 auctionId, address bidder);
+    error NativeTransferFailed(address recipient, uint256 amount);
+    error NoClaimableBalance(uint256 auctionId, address claimant);
+    error NoEscrowLocked(uint256 auctionId, address bidder);
     error NFTNotApproved(address nftContract, uint256 tokenId);
     error NotAuctionSeller(address caller, address seller);
     error NotNFTOwner(address nftContract, uint256 tokenId, address caller);
     error ReentrancyGuardReentrantCall();
+    error SellerProceedsAlreadyClaimed(uint256 auctionId);
+    error SlashedPotNotConfigured();
     error UnexpectedAuctionState(AuctionState expected, AuctionState actual);
+    error UnauthorizedAssetClaim(uint256 auctionId, address caller, address expectedRecipient);
     error ZeroAddress();
     error ZeroValue();
 
     uint256 public constant MIN_AUCTION_DURATION = 1 hours;
     uint256 public constant MAX_AUCTION_DURATION = 30 days;
+    uint256 private constant _DEFAULT_DYNAMIC_TIMEOUT = 30 minutes;
+    uint256 private constant _NETWORK_SAMPLE_CEILING = 10 minutes;
     uint256 private constant _NOT_ENTERED = 1;
     uint256 private constant _ENTERED = 2;
 
     mapping(uint256 => Auction) private _auctions;
     mapping(uint256 => mapping(address => uint256)) public escrowBalances;
     mapping(uint256 => mapping(address => bool)) public hasWithdrawn;
+    mapping(uint256 => mapping(address => bytes32)) private _encryptedBids;
 
     uint256 public auctionCounter;
     uint256 private _reentrancyStatus;
     address public slashedPot;
     ICofheAdapter public cofheAdapter;
+    ISettlementEngine public settlementEngine;
+    uint64 public lastObservationTimestamp;
+    uint64 public movingAverageBlockDelta;
 
     event AuctionCreated(
         uint256 indexed auctionId,
@@ -76,8 +104,14 @@ contract FhenixFairMarket is
         bool isVickrey
     );
     event AuctionStateChanged(uint256 indexed auctionId, AuctionState fromState, AuctionState toState);
+    event BidPlaced(uint256 indexed auctionId, address indexed bidder, bytes32 bidHandle);
     event EscrowLocked(uint256 indexed auctionId, address indexed bidder, uint256 amount);
-    event ResolutionRecorded(uint256 indexed auctionId, bytes32 winnerCiphertext, uint256 winningAmount);
+    event ResolutionRecorded(uint256 indexed auctionId, address indexed winner, bytes32 winnerCiphertext);
+    event RefundClaimed(uint256 indexed auctionId, address indexed claimant, uint256 escrowRefund, uint256 compensation);
+    event SellerProceedsClaimed(uint256 indexed auctionId, address indexed seller, uint256 amount);
+    event AssetClaimed(uint256 indexed auctionId, address indexed recipient, uint256 tokenId);
+    event SettlementDependenciesUpdated(address indexed settlementEngine, address indexed slashedPot);
+    event FallbackTriggered(uint256 indexed auctionId, uint256 elapsed, uint256 threshold);
 
     modifier auctionExists(uint256 auctionId) {
         if (!_auctions[auctionId].exists) {
@@ -124,7 +158,25 @@ contract FhenixFairMarket is
     }
 
     function contractVersion() public pure virtual returns (string memory) {
-        return "phase1";
+        return "phase2";
+    }
+
+    function setSettlementEngine(ISettlementEngine newSettlementEngine) external onlyOwner {
+        if (address(newSettlementEngine) == address(0)) {
+            revert ZeroAddress();
+        }
+
+        settlementEngine = newSettlementEngine;
+        emit SettlementDependenciesUpdated(address(newSettlementEngine), slashedPot);
+    }
+
+    function setSlashedPot(address newSlashedPot) external onlyOwner {
+        if (newSlashedPot == address(0)) {
+            revert ZeroAddress();
+        }
+
+        slashedPot = newSlashedPot;
+        emit SettlementDependenciesUpdated(address(settlementEngine), newSlashedPot);
     }
 
     function createAuction(
@@ -164,9 +216,11 @@ contract FhenixFairMarket is
         auction.sellerDeposit = sellerDeposit;
         auction.state = AuctionState.CREATED;
         auction.isVickrey = isVickrey;
+        auction.createdAt = uint64(block.timestamp);
         auction.lastBlockTimestamp = uint64(block.timestamp);
 
-        IERC721(nftContract).safeTransferFrom(msg.sender, address(this), tokenId);
+        _observeNetwork();
+        NFTGuard.lockIntoEscrow(nftContract, msg.sender, address(this), tokenId);
 
         _transitionState(auctionId, AuctionState.ACTIVE);
 
@@ -196,9 +250,41 @@ contract FhenixFairMarket is
         }
 
         escrowBalances[auctionId][msg.sender] += msg.value;
+        _auctions[auctionId].totalEscrow += msg.value;
         _auctions[auctionId].lastBlockTimestamp = uint64(block.timestamp);
+        _observeNetwork();
 
         emit EscrowLocked(auctionId, msg.sender, msg.value);
+    }
+
+    function placeBid(uint256 auctionId, bytes32 encryptedBid)
+        external
+        nonReentrant
+        auctionExists(auctionId)
+        onlyAuctionState(auctionId, AuctionState.ACTIVE)
+    {
+        Auction storage auction = _auctions[auctionId];
+        if (block.timestamp >= auction.endTime) {
+            revert AuctionAlreadyEnded(auctionId, auction.endTime);
+        }
+
+        uint256 availableEscrow = escrowBalances[auctionId][msg.sender];
+        if (availableEscrow == 0) {
+            revert NoEscrowLocked(auctionId, msg.sender);
+        }
+        if (!cofheAdapter.lte(encryptedBid, availableEscrow)) {
+            revert BidExceedsEscrow(auctionId, msg.sender);
+        }
+
+        if (_encryptedBids[auctionId][msg.sender] == bytes32(0)) {
+            auction.bidCount += 1;
+        }
+
+        _encryptedBids[auctionId][msg.sender] = encryptedBid;
+        auction.lastBlockTimestamp = uint64(block.timestamp);
+        _observeNetwork();
+
+        emit BidPlaced(auctionId, msg.sender, encryptedBid);
     }
 
     function triggerFinalize(uint256 auctionId)
@@ -210,7 +296,9 @@ contract FhenixFairMarket is
             revert AuctionStillRunning(auctionId, _auctions[auctionId].endTime);
         }
 
+        _observeNetwork();
         _transitionState(auctionId, AuctionState.RESOLVING);
+        _auctions[auctionId].resolvingSince = uint64(block.timestamp);
     }
 
     function submitResolution(
@@ -218,12 +306,16 @@ contract FhenixFairMarket is
         bytes32 winnerCiphertext,
         uint256 winningAmount
     ) external onlyOwner auctionExists(auctionId) onlyAuctionState(auctionId, AuctionState.RESOLVING) {
-        Auction storage auction = _auctions[auctionId];
-        auction.winnerCiphertext = winnerCiphertext;
-        auction.winningAmount = winningAmount;
+        _submitResolution(auctionId, address(0), winnerCiphertext, winningAmount);
+    }
 
-        _transitionState(auctionId, AuctionState.FINALIZED);
-        emit ResolutionRecorded(auctionId, winnerCiphertext, winningAmount);
+    function submitResolution(
+        uint256 auctionId,
+        address winner,
+        bytes32 winnerCiphertext,
+        uint256 winningAmount
+    ) external onlyOwner auctionExists(auctionId) onlyAuctionState(auctionId, AuctionState.RESOLVING) {
+        _submitResolution(auctionId, winner, winnerCiphertext, winningAmount);
     }
 
     function cancelAuction(uint256 auctionId)
@@ -238,21 +330,98 @@ contract FhenixFairMarket is
         }
 
         Auction storage auction = _auctions[auctionId];
-        IERC721(auction.nftContract).safeTransferFrom(address(this), auction.seller, auction.tokenId);
+        auction.slashAmount = _computeCancellationSlash(auction);
+        _registerSlash(auctionId, auction.totalEscrow, auction.slashAmount);
+        _observeNetwork();
 
+        NFTGuard.releaseFromEscrow(auction.nftContract, address(this), auction.seller, auction.tokenId);
         _transitionState(auctionId, AuctionState.CANCELLED);
     }
 
     function triggerFallbackVoid(uint256 auctionId)
         external
-        onlyOwner
+        nonReentrant
         auctionExists(auctionId)
         onlyAuctionState(auctionId, AuctionState.RESOLVING)
     {
         Auction storage auction = _auctions[auctionId];
-        IERC721(auction.nftContract).safeTransferFrom(address(this), auction.seller, auction.tokenId);
+        uint256 timeoutWindow = previewDynamicTimeout();
+        uint256 elapsed = block.timestamp - auction.resolvingSince;
 
+        if (elapsed < timeoutWindow) {
+            revert FallbackThresholdNotReached(elapsed, timeoutWindow);
+        }
+
+        auction.slashAmount = auction.totalEscrow == 0 ? 0 : auction.sellerDeposit;
+        _registerSlash(auctionId, auction.totalEscrow, auction.slashAmount);
+        _observeNetwork();
+
+        NFTGuard.releaseFromEscrow(auction.nftContract, address(this), auction.seller, auction.tokenId);
         _transitionState(auctionId, AuctionState.VOIDED);
+
+        emit FallbackTriggered(auctionId, elapsed, timeoutWindow);
+    }
+
+    function claimRefund(uint256 auctionId) external nonReentrant auctionExists(auctionId) {
+        if (hasWithdrawn[auctionId][msg.sender]) {
+            revert NoClaimableBalance(auctionId, msg.sender);
+        }
+
+        (uint256 escrowRefund, uint256 compensation) = previewRefund(auctionId, msg.sender);
+        if (escrowRefund == 0 && compensation == 0) {
+            revert NoClaimableBalance(auctionId, msg.sender);
+        }
+
+        hasWithdrawn[auctionId][msg.sender] = true;
+        if (escrowRefund != 0) {
+            escrowBalances[auctionId][msg.sender] = 0;
+            _sendValue(payable(msg.sender), escrowRefund);
+        }
+
+        if (compensation != 0) {
+            compensation = ISlashedPot(slashedPot).claimFor(auctionId, msg.sender, escrowRefund);
+        }
+
+        emit RefundClaimed(auctionId, msg.sender, escrowRefund, compensation);
+    }
+
+    function claimSellerProceeds(uint256 auctionId)
+        external
+        nonReentrant
+        auctionExists(auctionId)
+        onlyAuctionSeller(auctionId)
+    {
+        Auction storage auction = _auctions[auctionId];
+        if (auction.sellerClaimed) {
+            revert SellerProceedsAlreadyClaimed(auctionId);
+        }
+
+        uint256 sellerPayout = previewSellerPayout(auctionId);
+        if (sellerPayout == 0) {
+            revert NoClaimableBalance(auctionId, msg.sender);
+        }
+
+        auction.sellerClaimed = true;
+        _sendValue(payable(msg.sender), sellerPayout);
+
+        emit SellerProceedsClaimed(auctionId, msg.sender, sellerPayout);
+    }
+
+    function claimAsset(uint256 auctionId) external nonReentrant auctionExists(auctionId) onlyAuctionState(auctionId, AuctionState.FINALIZED) {
+        Auction storage auction = _auctions[auctionId];
+        if (auction.assetClaimed) {
+            revert AssetAlreadyClaimed(auctionId);
+        }
+
+        address expectedRecipient = auction.winner == address(0) ? auction.seller : auction.winner;
+        if (msg.sender != expectedRecipient) {
+            revert UnauthorizedAssetClaim(auctionId, msg.sender, expectedRecipient);
+        }
+
+        auction.assetClaimed = true;
+        NFTGuard.releaseFromEscrow(auction.nftContract, address(this), expectedRecipient, auction.tokenId);
+
+        emit AssetClaimed(auctionId, expectedRecipient, auction.tokenId);
     }
 
     function getAuction(uint256 auctionId)
@@ -287,11 +456,205 @@ contract FhenixFairMarket is
         );
     }
 
+    function getAuctionPhase2Details(uint256 auctionId)
+        external
+        view
+        auctionExists(auctionId)
+        returns (
+            address winner,
+            uint256 totalEscrow,
+            uint256 slashAmount,
+            uint64 createdAt,
+            uint64 resolvingSince,
+            bool sellerClaimed,
+            bool assetClaimed,
+            uint32 bidCount
+        )
+    {
+        Auction storage auction = _auctions[auctionId];
+        return (
+            auction.winner,
+            auction.totalEscrow,
+            auction.slashAmount,
+            auction.createdAt,
+            auction.resolvingSince,
+            auction.sellerClaimed,
+            auction.assetClaimed,
+            auction.bidCount
+        );
+    }
+
+    function getEncryptedBid(uint256 auctionId, address bidder)
+        external
+        view
+        auctionExists(auctionId)
+        returns (bytes32)
+    {
+        return _encryptedBids[auctionId][bidder];
+    }
+
+    function previewDynamicTimeout() public view returns (uint256) {
+        if (address(settlementEngine) == address(0)) {
+            return _DEFAULT_DYNAMIC_TIMEOUT;
+        }
+
+        return settlementEngine.computeDynamicTimeout(movingAverageBlockDelta);
+    }
+
+    function previewRefund(uint256 auctionId, address claimant)
+        public
+        view
+        auctionExists(auctionId)
+        returns (uint256 escrowRefund, uint256 compensation)
+    {
+        Auction storage auction = _auctions[auctionId];
+        uint256 escrowContribution = escrowBalances[auctionId][claimant];
+
+        if (auction.state == AuctionState.FINALIZED) {
+            if (claimant == auction.winner) {
+                escrowRefund = _computeWinningRefund(escrowContribution, auction.winningAmount);
+            } else {
+                escrowRefund = escrowContribution;
+            }
+
+            return (escrowRefund, 0);
+        }
+
+        if (auction.state == AuctionState.CANCELLED || auction.state == AuctionState.VOIDED) {
+            escrowRefund = escrowContribution;
+            if (escrowContribution != 0 && auction.slashAmount != 0 && slashedPot != address(0)) {
+                compensation = ISlashedPot(slashedPot).previewClaim(auctionId, escrowContribution);
+            }
+
+            return (escrowRefund, compensation);
+        }
+
+        return (0, 0);
+    }
+
+    function previewSellerPayout(uint256 auctionId) public view auctionExists(auctionId) returns (uint256) {
+        Auction storage auction = _auctions[auctionId];
+
+        if (auction.state == AuctionState.FINALIZED) {
+            return _computeSellerPayout(auction.sellerDeposit, auction.winningAmount);
+        }
+
+        if (auction.state == AuctionState.CANCELLED || auction.state == AuctionState.VOIDED) {
+            return _computeSellerCancellationPayout(auction.sellerDeposit, auction.slashAmount);
+        }
+
+        return 0;
+    }
+
     function onERC721Received(address, address, uint256, bytes calldata) external pure override returns (bytes4) {
         return IERC721Receiver.onERC721Received.selector;
     }
 
     function _authorizeUpgrade(address) internal override onlyOwner {}
+
+    function _submitResolution(uint256 auctionId, address winner, bytes32 winnerCiphertext, uint256 winningAmount) internal {
+        Auction storage auction = _auctions[auctionId];
+        if (winner != address(0)) {
+            if (_encryptedBids[auctionId][winner] == bytes32(0)) {
+                revert MissingEncryptedBid(auctionId, winner);
+            }
+            if (!cofheAdapter.lte(winnerCiphertext, escrowBalances[auctionId][winner])) {
+                revert BidExceedsEscrow(auctionId, winner);
+            }
+            if (winningAmount > escrowBalances[auctionId][winner]) {
+                revert InvalidWinningAmount(auctionId, winningAmount, escrowBalances[auctionId][winner]);
+            }
+        }
+
+        auction.winner = winner;
+        auction.winnerCiphertext = winnerCiphertext;
+        auction.winningAmount = winningAmount;
+        _observeNetwork();
+
+        _transitionState(auctionId, AuctionState.FINALIZED);
+        emit ResolutionRecorded(auctionId, winner, winnerCiphertext);
+    }
+
+    function _observeNetwork() internal {
+        uint64 currentTimestamp = uint64(block.timestamp);
+        if (lastObservationTimestamp == 0) {
+            lastObservationTimestamp = currentTimestamp;
+            return;
+        }
+
+        uint64 delta = currentTimestamp - lastObservationTimestamp;
+        if (delta == 0) {
+            return;
+        }
+        if (delta > _NETWORK_SAMPLE_CEILING) {
+            lastObservationTimestamp = currentTimestamp;
+            return;
+        }
+
+        if (movingAverageBlockDelta == 0) {
+            movingAverageBlockDelta = delta;
+        } else {
+            movingAverageBlockDelta = uint64((uint256(movingAverageBlockDelta) * 7 + delta) / 8);
+        }
+
+        lastObservationTimestamp = currentTimestamp;
+    }
+
+    function _registerSlash(uint256 auctionId, uint256 totalEscrow, uint256 slashAmount) internal {
+        if (slashAmount == 0) {
+            return;
+        }
+        if (slashedPot == address(0)) {
+            revert SlashedPotNotConfigured();
+        }
+
+        ISlashedPot(slashedPot).registerSlash{value: slashAmount}(auctionId, totalEscrow);
+    }
+
+    function _computeWinningRefund(uint256 escrowContribution, uint256 winningAmount) internal view returns (uint256) {
+        if (address(settlementEngine) == address(0)) {
+            return winningAmount >= escrowContribution ? 0 : escrowContribution - winningAmount;
+        }
+
+        return settlementEngine.computeWinningRefund(escrowContribution, winningAmount);
+    }
+
+    function _computeSellerPayout(uint256 sellerDeposit, uint256 winningAmount) internal view returns (uint256) {
+        if (address(settlementEngine) == address(0)) {
+            return sellerDeposit + winningAmount;
+        }
+
+        return settlementEngine.computeSellerPayout(sellerDeposit, winningAmount);
+    }
+
+    function _computeSellerCancellationPayout(uint256 sellerDeposit, uint256 slashAmount) internal view returns (uint256) {
+        if (address(settlementEngine) == address(0)) {
+            return slashAmount >= sellerDeposit ? 0 : sellerDeposit - slashAmount;
+        }
+
+        return settlementEngine.computeSellerCancellationPayout(sellerDeposit, slashAmount);
+    }
+
+    function _computeCancellationSlash(Auction storage auction) internal view returns (uint256) {
+        if (auction.totalEscrow == 0) {
+            return 0;
+        }
+        if (address(settlementEngine) == address(0)) {
+            return auction.sellerDeposit / 2;
+        }
+
+        uint256 elapsed = block.timestamp - auction.createdAt;
+        uint256 duration = uint256(auction.endTime) - auction.createdAt;
+
+        return settlementEngine.computeCancellationSlash(auction.sellerDeposit, elapsed, duration, auction.totalEscrow);
+    }
+
+    function _sendValue(address payable recipient, uint256 amount) internal {
+        (bool success,) = recipient.call{value: amount}("");
+        if (!success) {
+            revert NativeTransferFailed(recipient, amount);
+        }
+    }
 
     function _transitionState(uint256 auctionId, AuctionState nextState) internal {
         Auction storage auction = _auctions[auctionId];

--- a/packages/contracts/contracts/core/FhenixFairMarket.sol
+++ b/packages/contracts/contracts/core/FhenixFairMarket.sol
@@ -71,6 +71,8 @@ contract FhenixFairMarket is
     error SlashedPotNotConfigured();
     error UnexpectedAuctionState(AuctionState expected, AuctionState actual);
     error UnauthorizedAssetClaim(uint256 auctionId, address caller, address expectedRecipient);
+    error WinnerRequiredForWinningAmount(uint256 auctionId, uint256 winningAmount);
+    error ZeroWinningAmount(uint256 auctionId, address winner);
     error ZeroAddress();
     error ZeroValue();
 
@@ -554,7 +556,14 @@ contract FhenixFairMarket is
 
     function _submitResolution(uint256 auctionId, address winner, bytes32 winnerCiphertext, uint256 winningAmount) internal {
         Auction storage auction = _auctions[auctionId];
-        if (winner != address(0)) {
+        if (winner == address(0)) {
+            if (winningAmount != 0) {
+                revert WinnerRequiredForWinningAmount(auctionId, winningAmount);
+            }
+        } else {
+            if (winningAmount == 0) {
+                revert ZeroWinningAmount(auctionId, winner);
+            }
             if (_encryptedBids[auctionId][winner] == bytes32(0)) {
                 revert MissingEncryptedBid(auctionId, winner);
             }

--- a/packages/contracts/contracts/interfaces/ISettlementEngine.sol
+++ b/packages/contracts/contracts/interfaces/ISettlementEngine.sol
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+interface ISettlementEngine {
+    function computeDynamicTimeout(uint256 movingAverageBlockDelta) external pure returns (uint256);
+
+    function computeCancellationSlash(
+        uint256 sellerDeposit,
+        uint256 elapsed,
+        uint256 duration,
+        uint256 totalEscrow
+    ) external pure returns (uint256);
+
+    function computeWinningRefund(uint256 escrowedAmount, uint256 winningAmount) external pure returns (uint256);
+
+    function computeSellerPayout(uint256 sellerDeposit, uint256 winningAmount) external pure returns (uint256);
+
+    function computeSellerCancellationPayout(uint256 sellerDeposit, uint256 slashAmount) external pure returns (uint256);
+
+    function computeProRataShare(
+        uint256 contribution,
+        uint256 totalEscrow,
+        uint256 totalPot
+    ) external pure returns (uint256);
+}

--- a/packages/contracts/contracts/interfaces/ISlashedPot.sol
+++ b/packages/contracts/contracts/interfaces/ISlashedPot.sol
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+interface ISlashedPot {
+    function registerSlash(uint256 auctionId, uint256 totalEscrow) external payable;
+
+    function previewClaim(uint256 auctionId, uint256 escrowContribution) external view returns (uint256);
+
+    function claimFor(uint256 auctionId, address recipient, uint256 escrowContribution) external returns (uint256);
+}

--- a/packages/contracts/contracts/mocks/MockFhenixFairMarketV2.sol
+++ b/packages/contracts/contracts/mocks/MockFhenixFairMarketV2.sol
@@ -5,7 +5,7 @@ import "../core/FhenixFairMarket.sol";
 
 contract MockFhenixFairMarketV2 is FhenixFairMarket {
     function contractVersion() public pure override returns (string memory) {
-        return "phase1-v2";
+        return "phase2-v2";
     }
 
     function versionMarker() external pure returns (uint256) {

--- a/packages/contracts/contracts/mocks/MockRejectingReceiver.sol
+++ b/packages/contracts/contracts/mocks/MockRejectingReceiver.sol
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+contract MockRejectingReceiver {
+    receive() external payable {
+        revert("rejecting ether");
+    }
+}

--- a/packages/contracts/contracts/settlement/SettlementEngine.sol
+++ b/packages/contracts/contracts/settlement/SettlementEngine.sol
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+import "../interfaces/ISettlementEngine.sol";
+
+contract SettlementEngine is ISettlementEngine {
+    uint256 public constant BPS_DENOMINATOR = 10_000;
+    uint256 public constant MIN_DYNAMIC_TIMEOUT = 15 minutes;
+    uint256 public constant MAX_DYNAMIC_TIMEOUT = 2 hours;
+    uint256 public constant DYNAMIC_TIMEOUT_MULTIPLIER = 90;
+    uint256 public constant MIN_CANCELLATION_SLASH_BPS = 2_500;
+
+    function computeDynamicTimeout(uint256 movingAverageBlockDelta) external pure override returns (uint256) {
+        uint256 timeoutWindow = movingAverageBlockDelta == 0
+            ? MIN_DYNAMIC_TIMEOUT
+            : movingAverageBlockDelta * DYNAMIC_TIMEOUT_MULTIPLIER;
+
+        if (timeoutWindow < MIN_DYNAMIC_TIMEOUT) {
+            return MIN_DYNAMIC_TIMEOUT;
+        }
+        if (timeoutWindow > MAX_DYNAMIC_TIMEOUT) {
+            return MAX_DYNAMIC_TIMEOUT;
+        }
+
+        return timeoutWindow;
+    }
+
+    function computeCancellationSlash(
+        uint256 sellerDeposit,
+        uint256 elapsed,
+        uint256 duration,
+        uint256 totalEscrow
+    ) external pure override returns (uint256) {
+        if (sellerDeposit == 0 || totalEscrow == 0) {
+            return 0;
+        }
+        if (duration == 0) {
+            return sellerDeposit;
+        }
+
+        uint256 boundedElapsed = elapsed > duration ? duration : elapsed;
+        uint256 progressBps = (boundedElapsed * BPS_DENOMINATOR) / duration;
+        uint256 slashBps = MIN_CANCELLATION_SLASH_BPS +
+            ((progressBps * (BPS_DENOMINATOR - MIN_CANCELLATION_SLASH_BPS)) / BPS_DENOMINATOR);
+
+        return (sellerDeposit * slashBps) / BPS_DENOMINATOR;
+    }
+
+    function computeWinningRefund(uint256 escrowedAmount, uint256 winningAmount)
+        external
+        pure
+        override
+        returns (uint256)
+    {
+        return winningAmount >= escrowedAmount ? 0 : escrowedAmount - winningAmount;
+    }
+
+    function computeSellerPayout(uint256 sellerDeposit, uint256 winningAmount)
+        external
+        pure
+        override
+        returns (uint256)
+    {
+        return sellerDeposit + winningAmount;
+    }
+
+    function computeSellerCancellationPayout(uint256 sellerDeposit, uint256 slashAmount)
+        external
+        pure
+        override
+        returns (uint256)
+    {
+        return slashAmount >= sellerDeposit ? 0 : sellerDeposit - slashAmount;
+    }
+
+    function computeProRataShare(
+        uint256 contribution,
+        uint256 totalEscrow,
+        uint256 totalPot
+    ) external pure override returns (uint256) {
+        if (contribution == 0 || totalEscrow == 0 || totalPot == 0) {
+            return 0;
+        }
+
+        return (contribution * totalPot) / totalEscrow;
+    }
+}

--- a/packages/contracts/contracts/settlement/SlashedPot.sol
+++ b/packages/contracts/contracts/settlement/SlashedPot.sol
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+import "@openzeppelin/contracts/access/Ownable.sol";
+
+import "../interfaces/ISettlementEngine.sol";
+
+contract SlashedPot is Ownable {
+    struct Pot {
+        bool exists;
+        uint256 totalEscrow;
+        uint256 totalSlash;
+    }
+
+    error CompensationAlreadyClaimed(uint256 auctionId, address recipient);
+    error NativeTransferFailed(address recipient, uint256 amount);
+    error NotMarket(address caller);
+    error ZeroAddress();
+
+    mapping(uint256 => Pot) private _pots;
+    mapping(uint256 => mapping(address => bool)) public hasClaimedCompensation;
+
+    ISettlementEngine public immutable settlementEngine;
+    address public market;
+
+    event CompensationClaimed(uint256 indexed auctionId, address indexed recipient, uint256 amount);
+    event MarketUpdated(address indexed previousMarket, address indexed newMarket);
+    event SlashRegistered(uint256 indexed auctionId, uint256 totalEscrow, uint256 totalSlash);
+
+    constructor(address initialOwner, ISettlementEngine engine) Ownable(initialOwner) {
+        if (address(engine) == address(0)) {
+            revert ZeroAddress();
+        }
+
+        settlementEngine = engine;
+    }
+
+    modifier onlyMarket() {
+        if (msg.sender != market) {
+            revert NotMarket(msg.sender);
+        }
+        _;
+    }
+
+    function setMarket(address newMarket) external onlyOwner {
+        if (newMarket == address(0)) {
+            revert ZeroAddress();
+        }
+
+        address previousMarket = market;
+        market = newMarket;
+        emit MarketUpdated(previousMarket, newMarket);
+    }
+
+    function registerSlash(uint256 auctionId, uint256 totalEscrow) external payable onlyMarket {
+        Pot storage pot = _pots[auctionId];
+        if (!pot.exists) {
+            pot.exists = true;
+            pot.totalEscrow = totalEscrow;
+        }
+
+        pot.totalSlash += msg.value;
+        emit SlashRegistered(auctionId, pot.totalEscrow, pot.totalSlash);
+    }
+
+    function previewClaim(uint256 auctionId, uint256 escrowContribution) public view returns (uint256) {
+        Pot storage pot = _pots[auctionId];
+        return settlementEngine.computeProRataShare(escrowContribution, pot.totalEscrow, pot.totalSlash);
+    }
+
+    function claimFor(uint256 auctionId, address recipient, uint256 escrowContribution)
+        external
+        onlyMarket
+        returns (uint256 amount)
+    {
+        if (hasClaimedCompensation[auctionId][recipient]) {
+            revert CompensationAlreadyClaimed(auctionId, recipient);
+        }
+
+        hasClaimedCompensation[auctionId][recipient] = true;
+        amount = previewClaim(auctionId, escrowContribution);
+
+        if (amount == 0) {
+            return 0;
+        }
+
+        (bool success,) = payable(recipient).call{value: amount}("");
+        if (!success) {
+            revert NativeTransferFailed(recipient, amount);
+        }
+
+        emit CompensationClaimed(auctionId, recipient, amount);
+    }
+}

--- a/packages/contracts/deploy/00_deploy_adapters.ts
+++ b/packages/contracts/deploy/00_deploy_adapters.ts
@@ -22,15 +22,21 @@ async function main() {
   const adapter = await adapterFactory.deploy();
   await adapter.waitForDeployment();
 
+  const settlementEngineFactory = await ethers.getContractFactory("SettlementEngine");
+  const settlementEngine = await settlementEngineFactory.deploy();
+  await settlementEngine.waitForDeployment();
+
   const existing = await readDeploymentFile(deploymentFile);
   const nextPayload = {
     ...existing,
-    adapter: await adapter.getAddress()
+    adapter: await adapter.getAddress(),
+    settlementEngine: await settlementEngine.getAddress()
   };
 
   await writeFile(deploymentFile, `${JSON.stringify(nextPayload, null, 2)}\n`, "utf8");
 
   console.log(`Adapter deployed to ${nextPayload.adapter}`);
+  console.log(`SettlementEngine deployed to ${nextPayload.settlementEngine}`);
 }
 
 main().catch((error) => {

--- a/packages/contracts/deploy/01_deploy_core_proxy.ts
+++ b/packages/contracts/deploy/01_deploy_core_proxy.ts
@@ -36,7 +36,35 @@ async function main() {
 
   const [defaultSigner] = await ethers.getSigners();
   const initialOwner = process.env.PHASE1_INITIAL_OWNER || defaultSigner.address;
-  const slashedPot = process.env.PHASE1_SLASHED_POT || ethers.ZeroAddress;
+  let settlementEngineAddress = process.env.PHASE2_SETTLEMENT_ENGINE || existing.settlementEngine;
+  if (settlementEngineAddress) {
+    const deployedCode = await ethers.provider.getCode(settlementEngineAddress);
+    if (deployedCode === "0x") {
+      settlementEngineAddress = undefined;
+    }
+  }
+
+  if (!settlementEngineAddress) {
+    const settlementEngineFactory = await ethers.getContractFactory("SettlementEngine");
+    const settlementEngine = await settlementEngineFactory.deploy();
+    await settlementEngine.waitForDeployment();
+    settlementEngineAddress = await settlementEngine.getAddress();
+  }
+
+  let slashedPot = process.env.PHASE1_SLASHED_POT || existing.slashedPot;
+  if (slashedPot && slashedPot !== ethers.ZeroAddress) {
+    const deployedCode = await ethers.provider.getCode(slashedPot);
+    if (deployedCode === "0x") {
+      slashedPot = undefined;
+    }
+  }
+
+  if (!slashedPot || slashedPot === ethers.ZeroAddress) {
+    const slashedPotFactory = await ethers.getContractFactory("SlashedPot");
+    const slashedPotInstance = await slashedPotFactory.deploy(initialOwner, settlementEngineAddress);
+    await slashedPotInstance.waitForDeployment();
+    slashedPot = await slashedPotInstance.getAddress();
+  }
 
   const implementationFactory = await ethers.getContractFactory("FhenixFairMarket");
   const implementation = await implementationFactory.deploy();
@@ -52,9 +80,22 @@ async function main() {
   const proxy = await proxyFactory.deploy(await implementation.getAddress(), initData);
   await proxy.waitForDeployment();
 
+  const market = implementationFactory.attach(await proxy.getAddress());
+  const slashedPotFactory = await ethers.getContractFactory("SlashedPot");
+  const slashedPotInstance = slashedPotFactory.attach(slashedPot);
+
+  if ((await slashedPotInstance.market()) != (await proxy.getAddress())) {
+    await (await slashedPotInstance.connect(defaultSigner).setMarket(await proxy.getAddress())).wait();
+  }
+
+  if ((await market.settlementEngine()) != settlementEngineAddress) {
+    await (await market.connect(defaultSigner).setSettlementEngine(settlementEngineAddress)).wait();
+  }
+
   const nextPayload = {
     ...existing,
     adapter: adapterAddress,
+    settlementEngine: settlementEngineAddress,
     implementation: await implementation.getAddress(),
     proxy: await proxy.getAddress(),
     initialOwner,
@@ -65,6 +106,8 @@ async function main() {
 
   console.log(`Implementation deployed to ${nextPayload.implementation}`);
   console.log(`Proxy deployed to ${nextPayload.proxy}`);
+  console.log(`SlashedPot deployed to ${nextPayload.slashedPot}`);
+  console.log(`SettlementEngine configured at ${nextPayload.settlementEngine}`);
 }
 
 main().catch((error) => {

--- a/packages/contracts/test/helpers/fixtures.ts
+++ b/packages/contracts/test/helpers/fixtures.ts
@@ -1,0 +1,73 @@
+import { ethers } from "hardhat";
+
+export async function deployPhase2Fixture() {
+  const [owner, seller, bidder, bidderTwo, outsider] = await ethers.getSigners();
+
+  const adapterFactory = await ethers.getContractFactory("CofheAdapter");
+  const adapter = await adapterFactory.deploy();
+  await adapter.waitForDeployment();
+
+  const settlementEngineFactory = await ethers.getContractFactory("SettlementEngine");
+  const settlementEngine = await settlementEngineFactory.deploy();
+  await settlementEngine.waitForDeployment();
+
+  const slashedPotFactory = await ethers.getContractFactory("SlashedPot");
+  const slashedPot = await slashedPotFactory.deploy(owner.address, await settlementEngine.getAddress());
+  await slashedPot.waitForDeployment();
+
+  const implementationFactory = await ethers.getContractFactory("FhenixFairMarket");
+  const implementation = await implementationFactory.deploy();
+  await implementation.waitForDeployment();
+
+  const proxyFactory = await ethers.getContractFactory("FhenixFairMarketProxy");
+  const initData = implementationFactory.interface.encodeFunctionData("initialize", [
+    await adapter.getAddress(),
+    owner.address,
+    await slashedPot.getAddress()
+  ]);
+
+  const proxy = await proxyFactory.deploy(await implementation.getAddress(), initData);
+  await proxy.waitForDeployment();
+
+  const market = implementationFactory.attach(await proxy.getAddress());
+  await market.connect(owner).setSettlementEngine(await settlementEngine.getAddress());
+  await slashedPot.connect(owner).setMarket(await market.getAddress());
+
+  const nftFactory = await ethers.getContractFactory("MockERC721");
+  const nft = await nftFactory.deploy();
+  await nft.waitForDeployment();
+
+  const mockCofheFactory = await ethers.getContractFactory("MockCofhe");
+  const mockCofhe = await mockCofheFactory.deploy();
+  await mockCofhe.waitForDeployment();
+
+  return {
+    owner,
+    seller,
+    bidder,
+    bidderTwo,
+    outsider,
+    adapter,
+    settlementEngine,
+    slashedPot,
+    implementation,
+    proxy,
+    market,
+    nft,
+    mockCofhe
+  };
+}
+
+export async function createPhase2AuctionFixture() {
+  const context = await deployPhase2Fixture();
+  const { market, nft, seller } = context;
+
+  await nft.connect(seller).mint(seller.address);
+  await nft.connect(seller).approve(await market.getAddress(), 1n);
+
+  await market.connect(seller).createAuction(await nft.getAddress(), 1n, 24 * 60 * 60, ethers.parseEther("1"), true, {
+    value: ethers.parseEther("1")
+  });
+
+  return context;
+}

--- a/packages/contracts/test/integration/Phase1Workflow.test.ts
+++ b/packages/contracts/test/integration/Phase1Workflow.test.ts
@@ -23,6 +23,7 @@ describe("Phase 1 integration workflow", function () {
 
     const encryptedWinningBid = await adapter.asEuint32(450);
     expect(await adapter.verifyEncryptedBidCoverage(encryptedWinningBid, 600n)).to.equal(true);
+    await market.connect(bidder).placeBid(1n, encryptedWinningBid);
 
     const encryptedWinner = await adapter.select(
       await adapter.asEbool(true),
@@ -33,7 +34,12 @@ describe("Phase 1 integration workflow", function () {
 
     await time.increase(24 * 60 * 60 + 1);
     await market.triggerFinalize(1n);
-    await market.connect(owner)["submitResolution(uint256,bytes32,uint256)"](1n, encryptedWinner, 450n);
+    await market.connect(owner)["submitResolution(uint256,address,bytes32,uint256)"](
+      1n,
+      bidder.address,
+      encryptedWinner,
+      450n
+    );
 
     const auction = await market.getAuction(1n);
     expect(auction[5]).to.equal(3n);

--- a/packages/contracts/test/integration/Phase1Workflow.test.ts
+++ b/packages/contracts/test/integration/Phase1Workflow.test.ts
@@ -1,48 +1,11 @@
 import { loadFixture, time } from "@nomicfoundation/hardhat-network-helpers";
 import { expect } from "chai";
-import { ethers } from "hardhat";
+
+import { deployPhase2Fixture } from "../helpers/fixtures";
 
 describe("Phase 1 integration workflow", function () {
   async function deployFixture() {
-    const [owner, seller, bidder] = await ethers.getSigners();
-
-    const adapterFactory = await ethers.getContractFactory("CofheAdapter");
-    const adapter = await adapterFactory.deploy();
-    await adapter.waitForDeployment();
-
-    const implementationFactory = await ethers.getContractFactory("FhenixFairMarket");
-    const implementation = await implementationFactory.deploy();
-    await implementation.waitForDeployment();
-
-    const proxyFactory = await ethers.getContractFactory("FhenixFairMarketProxy");
-    const initData = implementationFactory.interface.encodeFunctionData("initialize", [
-      await adapter.getAddress(),
-      owner.address,
-      ethers.ZeroAddress
-    ]);
-
-    const proxy = await proxyFactory.deploy(await implementation.getAddress(), initData);
-    await proxy.waitForDeployment();
-
-    const market = implementationFactory.attach(await proxy.getAddress());
-
-    const nftFactory = await ethers.getContractFactory("MockERC721");
-    const nft = await nftFactory.deploy();
-    await nft.waitForDeployment();
-
-    const mockCofheFactory = await ethers.getContractFactory("MockCofhe");
-    const mockCofhe = await mockCofheFactory.deploy();
-    await mockCofhe.waitForDeployment();
-
-    return {
-      owner,
-      seller,
-      bidder,
-      adapter,
-      market,
-      nft,
-      mockCofhe
-    };
+    return deployPhase2Fixture();
   }
 
   it("executes the Phase 1 scaffold from escrow to encrypted resolution", async function () {
@@ -70,7 +33,7 @@ describe("Phase 1 integration workflow", function () {
 
     await time.increase(24 * 60 * 60 + 1);
     await market.triggerFinalize(1n);
-    await market.connect(owner).submitResolution(1n, encryptedWinner, 450n);
+    await market.connect(owner)["submitResolution(uint256,bytes32,uint256)"](1n, encryptedWinner, 450n);
 
     const auction = await market.getAuction(1n);
     expect(auction[5]).to.equal(3n);

--- a/packages/contracts/test/unit/AsyncResolution.test.ts
+++ b/packages/contracts/test/unit/AsyncResolution.test.ts
@@ -75,6 +75,21 @@ describe("Phase 2 async resolution and settlement", function () {
     await expect(market.connect(bidder).claimAsset(1n)).to.be.revertedWithCustomError(market, "AssetAlreadyClaimed");
   });
 
+  it("rejects winner resolutions that try to settle at zero", async function () {
+    const { adapter, bidder, market, owner } = await loadFixture(createPhase2AuctionFixture);
+
+    await market.connect(bidder).lockEscrow(1n, { value: 600n });
+    const winnerBid = await adapter.asEuint32(450);
+    await market.connect(bidder).placeBid(1n, winnerBid);
+
+    await time.increase(24 * 60 * 60 + 1);
+    await market.triggerFinalize(1n);
+
+    await expect(
+      market.connect(owner)["submitResolution(uint256,address,bytes32,uint256)"](1n, bidder.address, winnerBid, 0n)
+    ).to.be.revertedWithCustomError(market, "ZeroWinningAmount");
+  });
+
   it("routes seller slashing into the compensation pot and distributes refunds without loops on cancellation", async function () {
     const { adapter, bidder, bidderTwo, market, seller, slashedPot } = await loadFixture(createPhase2AuctionFixture);
 

--- a/packages/contracts/test/unit/AsyncResolution.test.ts
+++ b/packages/contracts/test/unit/AsyncResolution.test.ts
@@ -1,0 +1,112 @@
+import { loadFixture, time } from "@nomicfoundation/hardhat-network-helpers";
+import { expect } from "chai";
+import { ethers } from "hardhat";
+
+import { createPhase2AuctionFixture } from "../helpers/fixtures";
+
+describe("Phase 2 async resolution and settlement", function () {
+  it("rejects encrypted bids that exceed the caller's escrow and stores valid bid handles", async function () {
+    const { adapter, bidder, market } = await loadFixture(createPhase2AuctionFixture);
+
+    await market.connect(bidder).lockEscrow(1n, { value: 600n });
+
+    const oversizedBid = await adapter.asEuint32(601);
+    await expect(market.connect(bidder).placeBid(1n, oversizedBid)).to.be.revertedWithCustomError(
+      market,
+      "BidExceedsEscrow"
+    );
+
+    const validBid = await adapter.asEuint32(550);
+    await expect(market.connect(bidder).placeBid(1n, validBid))
+      .to.emit(market, "BidPlaced")
+      .withArgs(1n, bidder.address, validBid);
+
+    expect(await market.getEncryptedBid(1n, bidder.address)).to.equal(validBid);
+
+    const phase2Details = await market.getAuctionPhase2Details(1n);
+    expect(phase2Details[7]).to.equal(1n);
+  });
+
+  it("settles finalized auctions through pull-based refunds, seller proceeds, and deferred NFT claims", async function () {
+    const { adapter, bidder, bidderTwo, market, nft, owner, seller } = await loadFixture(createPhase2AuctionFixture);
+
+    await market.connect(bidder).lockEscrow(1n, { value: 600n });
+    await market.connect(bidderTwo).lockEscrow(1n, { value: 500n });
+
+    const winnerBid = await adapter.asEuint32(450);
+    const runnerUpBid = await adapter.asEuint32(420);
+
+    await market.connect(bidder).placeBid(1n, winnerBid);
+    await market.connect(bidderTwo).placeBid(1n, runnerUpBid);
+
+    await time.increase(24 * 60 * 60 + 1);
+    await market.triggerFinalize(1n);
+
+    await expect(market.connect(owner)["submitResolution(uint256,address,bytes32,uint256)"](1n, bidder.address, winnerBid, 450n))
+      .to.emit(market, "ResolutionRecorded")
+      .withArgs(1n, bidder.address, winnerBid);
+
+    const winnerPreview = await market.previewRefund(1n, bidder.address);
+    const runnerUpPreview = await market.previewRefund(1n, bidderTwo.address);
+    const sellerPreview = await market.previewSellerPayout(1n);
+
+    expect(winnerPreview[0]).to.equal(150n);
+    expect(winnerPreview[1]).to.equal(0n);
+    expect(runnerUpPreview[0]).to.equal(500n);
+    expect(runnerUpPreview[1]).to.equal(0n);
+    expect(sellerPreview).to.equal(ethers.parseEther("1") + 450n);
+
+    await market.connect(bidderTwo).claimRefund(1n);
+    await market.connect(bidder).claimRefund(1n);
+    await market.connect(seller).claimSellerProceeds(1n);
+    await market.connect(bidder).claimAsset(1n);
+
+    expect(await market.hasWithdrawn(1n, bidder.address)).to.equal(true);
+    expect(await market.hasWithdrawn(1n, bidderTwo.address)).to.equal(true);
+    expect(await market.escrowBalances(1n, bidder.address)).to.equal(0n);
+    expect(await market.escrowBalances(1n, bidderTwo.address)).to.equal(0n);
+    expect(await nft.ownerOf(1n)).to.equal(bidder.address);
+    expect(await ethers.provider.getBalance(await market.getAddress())).to.equal(0n);
+
+    await expect(market.connect(seller).claimSellerProceeds(1n)).to.be.revertedWithCustomError(
+      market,
+      "SellerProceedsAlreadyClaimed"
+    );
+    await expect(market.connect(bidder).claimAsset(1n)).to.be.revertedWithCustomError(market, "AssetAlreadyClaimed");
+  });
+
+  it("routes seller slashing into the compensation pot and distributes refunds without loops on cancellation", async function () {
+    const { adapter, bidder, bidderTwo, market, seller, slashedPot } = await loadFixture(createPhase2AuctionFixture);
+
+    await market.connect(bidder).lockEscrow(1n, { value: 600n });
+    await market.connect(bidderTwo).lockEscrow(1n, { value: 400n });
+
+    await market.connect(bidder).placeBid(1n, await adapter.asEuint32(450));
+    await market.connect(bidderTwo).placeBid(1n, await adapter.asEuint32(350));
+
+    await time.increase(12 * 60 * 60);
+    await market.connect(seller).cancelAuction(1n);
+
+    const phase2Details = await market.getAuctionPhase2Details(1n);
+    const slashAmount = phase2Details[2];
+    expect(slashAmount).to.be.greaterThan(0n);
+    expect(await ethers.provider.getBalance(await slashedPot.getAddress())).to.equal(slashAmount);
+
+    const bidderPreview = await market.previewRefund(1n, bidder.address);
+    const bidderTwoPreview = await market.previewRefund(1n, bidderTwo.address);
+    const sellerPreview = await market.previewSellerPayout(1n);
+
+    expect(bidderPreview[0]).to.equal(600n);
+    expect(bidderTwoPreview[0]).to.equal(400n);
+    expect(bidderPreview[1] + bidderTwoPreview[1]).to.be.lessThanOrEqual(slashAmount);
+    expect(sellerPreview + bidderPreview[1] + bidderTwoPreview[1]).to.be.lessThanOrEqual(ethers.parseEther("1"));
+
+    await market.connect(bidder).claimRefund(1n);
+    await market.connect(bidderTwo).claimRefund(1n);
+    await market.connect(seller).claimSellerProceeds(1n);
+
+    expect(await market.hasWithdrawn(1n, bidder.address)).to.equal(true);
+    expect(await market.hasWithdrawn(1n, bidderTwo.address)).to.equal(true);
+    expect(await ethers.provider.getBalance(await market.getAddress())).to.equal(0n);
+  });
+});

--- a/packages/contracts/test/unit/DynamicTimeout.test.ts
+++ b/packages/contracts/test/unit/DynamicTimeout.test.ts
@@ -1,0 +1,83 @@
+import { loadFixture, time } from "@nomicfoundation/hardhat-network-helpers";
+import { anyValue } from "@nomicfoundation/hardhat-chai-matchers/withArgs";
+import { expect } from "chai";
+import { ethers } from "hardhat";
+
+import { createPhase2AuctionFixture } from "../helpers/fixtures";
+
+async function advanceWithHeartbeat(seconds: number, callback: () => Promise<unknown>) {
+  await time.increase(seconds);
+  await callback();
+}
+
+describe("Phase 2 dynamic timeout and fallback logic", function () {
+  it("voids a resolving auction after a 30 minute sequencer outage and restores bidder liquidity", async function () {
+    const { adapter, bidder, market, nft, seller } = await loadFixture(createPhase2AuctionFixture);
+
+    await market.connect(bidder).lockEscrow(1n, { value: 600n });
+    await market.connect(bidder).placeBid(1n, await adapter.asEuint32(500));
+
+    await advanceWithHeartbeat(12, () => market.connect(bidder).lockEscrow(1n, { value: 1n }));
+    await advanceWithHeartbeat(12, () => market.connect(bidder).lockEscrow(1n, { value: 1n }));
+
+    const auctionBeforeEnd = await market.getAuction(1n);
+    const finalizeAt = Number(auctionBeforeEnd[3]) - 15;
+    await time.increaseTo(finalizeAt);
+    await market.connect(bidder).lockEscrow(1n, { value: 1n });
+
+    const timeoutWindow = await market.previewDynamicTimeout();
+    expect(timeoutWindow).to.be.lessThan(30n * 60n);
+
+    await time.increase(16);
+    await market.triggerFinalize(1n);
+
+    await expect(market.triggerFallbackVoid(1n)).to.be.revertedWithCustomError(market, "FallbackThresholdNotReached");
+
+    await time.increase(30 * 60);
+    await expect(market.triggerFallbackVoid(1n))
+      .to.emit(market, "FallbackTriggered")
+      .withArgs(1n, anyValue, timeoutWindow);
+
+    const phase2Details = await market.getAuctionPhase2Details(1n);
+    expect(phase2Details[2]).to.equal(ethers.parseEther("1"));
+    expect(await nft.ownerOf(1n)).to.equal(seller.address);
+
+    const refundPreview = await market.previewRefund(1n, bidder.address);
+    expect(refundPreview[0]).to.equal(603n);
+    expect(refundPreview[1]).to.equal(ethers.parseEther("1"));
+
+    await market.connect(bidder).claimRefund(1n);
+    expect(await market.previewSellerPayout(1n)).to.equal(0n);
+  });
+
+  it("expands the emergency threshold when the moving block-time average rises under congestion", async function () {
+    const { adapter, bidder, market } = await loadFixture(createPhase2AuctionFixture);
+
+    await market.connect(bidder).lockEscrow(1n, { value: 700n });
+    await market.connect(bidder).placeBid(1n, await adapter.asEuint32(500));
+
+    await advanceWithHeartbeat(5 * 60, () => market.connect(bidder).lockEscrow(1n, { value: 1n }));
+    await advanceWithHeartbeat(5 * 60, () => market.connect(bidder).lockEscrow(1n, { value: 1n }));
+    await advanceWithHeartbeat(5 * 60, () => market.connect(bidder).lockEscrow(1n, { value: 1n }));
+
+    const auctionBeforeEnd = await market.getAuction(1n);
+    const finalizeAt = Number(auctionBeforeEnd[3]) - 301;
+    await time.increaseTo(finalizeAt);
+    await market.connect(bidder).lockEscrow(1n, { value: 1n });
+
+    const timeoutWindow = await market.previewDynamicTimeout();
+    expect(timeoutWindow).to.be.greaterThan(30n * 60n);
+
+    await time.increase(302);
+    await market.triggerFinalize(1n);
+
+    await time.increase(30 * 60);
+    await expect(market.triggerFallbackVoid(1n)).to.be.revertedWithCustomError(market, "FallbackThresholdNotReached");
+
+    await time.increase(Number(timeoutWindow));
+    await market.triggerFallbackVoid(1n);
+
+    const auction = await market.getAuction(1n);
+    expect(auction[5]).to.equal(5n);
+  });
+});

--- a/packages/contracts/test/unit/EscrowLogic.test.ts
+++ b/packages/contracts/test/unit/EscrowLogic.test.ts
@@ -3,73 +3,22 @@ import { anyValue } from "@nomicfoundation/hardhat-chai-matchers/withArgs";
 import { expect } from "chai";
 import { ethers } from "hardhat";
 
+import { createPhase2AuctionFixture, deployPhase2Fixture } from "../helpers/fixtures";
+
 describe("FhenixFairMarket Phase 1", function () {
   async function deployFixture() {
-    const [owner, seller, bidder, outsider] = await ethers.getSigners();
-
-    const adapterFactory = await ethers.getContractFactory("CofheAdapter");
-    const adapter = await adapterFactory.deploy();
-    await adapter.waitForDeployment();
-
-    const implementationFactory = await ethers.getContractFactory("FhenixFairMarket");
-    const implementation = await implementationFactory.deploy();
-    await implementation.waitForDeployment();
-
-    const proxyFactory = await ethers.getContractFactory("FhenixFairMarketProxy");
-    const initData = implementationFactory.interface.encodeFunctionData("initialize", [
-      await adapter.getAddress(),
-      owner.address,
-      ethers.ZeroAddress
-    ]);
-
-    const proxy = await proxyFactory.deploy(await implementation.getAddress(), initData);
-    await proxy.waitForDeployment();
-
-    const market = implementationFactory.attach(await proxy.getAddress());
-
-    const nftFactory = await ethers.getContractFactory("MockERC721");
-    const nft = await nftFactory.deploy();
-    await nft.waitForDeployment();
-
-    const mockCofheFactory = await ethers.getContractFactory("MockCofhe");
-    const mockCofhe = await mockCofheFactory.deploy();
-    await mockCofhe.waitForDeployment();
-
-    return {
-      owner,
-      seller,
-      bidder,
-      outsider,
-      adapter,
-      implementation,
-      proxy,
-      market,
-      nft,
-      mockCofhe
-    };
+    return deployPhase2Fixture();
   }
 
   async function createAuctionFixture() {
-    const context = await deployFixture();
-    const { market, nft, seller } = context;
-
-    await nft.connect(seller).mint(seller.address);
-    await nft.connect(seller).approve(await market.getAddress(), 1n);
-
-    await market
-      .connect(seller)
-      .createAuction(await nft.getAddress(), 1n, 24 * 60 * 60, ethers.parseEther("1"), true, {
-        value: ethers.parseEther("1")
-      });
-
-    return context;
+    return createPhase2AuctionFixture();
   }
 
   it("initializes once through the proxy", async function () {
     const { market, adapter, owner } = await loadFixture(deployFixture);
 
     await expect(market.initialize(await adapter.getAddress(), owner.address, ethers.ZeroAddress)).to.be.reverted;
-    expect(await market.contractVersion()).to.equal("phase1");
+    expect(await market.contractVersion()).to.equal("phase2");
   });
 
   it("rejects invalid initialization parameters on a fresh implementation", async function () {
@@ -244,9 +193,9 @@ describe("FhenixFairMarket Phase 1", function () {
     await market.triggerFinalize(1n);
 
     const cipher = ethers.encodeBytes32String("winner");
-    await expect(market.connect(owner).submitResolution(1n, cipher, 77n))
+    await expect(market.connect(owner)["submitResolution(uint256,bytes32,uint256)"](1n, cipher, 77n))
       .to.emit(market, "ResolutionRecorded")
-      .withArgs(1n, cipher, 77n);
+      .withArgs(1n, ethers.ZeroAddress, cipher);
 
     const auction = await market.getAuction(1n);
     expect(auction[5]).to.equal(3n);
@@ -258,7 +207,7 @@ describe("FhenixFairMarket Phase 1", function () {
     const { market, owner } = await loadFixture(createAuctionFixture);
 
     await expect(
-      market.connect(owner).submitResolution(1n, ethers.encodeBytes32String("winner"), 10n)
+      market.connect(owner)["submitResolution(uint256,bytes32,uint256)"](1n, ethers.encodeBytes32String("winner"), 10n)
     ).to.be.revertedWithCustomError(market, "UnexpectedAuctionState");
   });
 
@@ -287,11 +236,12 @@ describe("FhenixFairMarket Phase 1", function () {
     );
   });
 
-  it("allows the owner to void a stuck resolving auction", async function () {
+  it("allows fallback void once the resolving timeout window has elapsed", async function () {
     const { market, nft, seller } = await loadFixture(createAuctionFixture);
 
     await time.increase(24 * 60 * 60 + 1);
     await market.triggerFinalize(1n);
+    await time.increase(await market.previewDynamicTimeout());
     await market.triggerFallbackVoid(1n);
 
     const auction = await market.getAuction(1n);
@@ -319,7 +269,7 @@ describe("FhenixFairMarket Phase 1", function () {
     await market.upgradeToAndCall(await v2Implementation.getAddress(), "0x");
 
     const upgraded = v2Factory.attach(await proxy.getAddress());
-    expect(await upgraded.contractVersion()).to.equal("phase1-v2");
+    expect(await upgraded.contractVersion()).to.equal("phase2-v2");
     expect(await upgraded.versionMarker()).to.equal(2n);
   });
 

--- a/packages/contracts/test/unit/EscrowLogic.test.ts
+++ b/packages/contracts/test/unit/EscrowLogic.test.ts
@@ -186,21 +186,31 @@ describe("FhenixFairMarket Phase 1", function () {
     await expect(market.triggerFinalize(1n)).to.be.revertedWithCustomError(market, "AuctionStillRunning");
   });
 
-  it("records a minimal resolution from the owner once resolving", async function () {
+  it("allows a no-winner resolution only when the winning amount is zero", async function () {
     const { market, owner } = await loadFixture(createAuctionFixture);
 
     await time.increase(24 * 60 * 60 + 1);
     await market.triggerFinalize(1n);
 
-    const cipher = ethers.encodeBytes32String("winner");
-    await expect(market.connect(owner)["submitResolution(uint256,bytes32,uint256)"](1n, cipher, 77n))
+    await expect(market.connect(owner)["submitResolution(uint256,bytes32,uint256)"](1n, ethers.ZeroHash, 0n))
       .to.emit(market, "ResolutionRecorded")
-      .withArgs(1n, ethers.ZeroAddress, cipher);
+      .withArgs(1n, ethers.ZeroAddress, ethers.ZeroHash);
 
     const auction = await market.getAuction(1n);
     expect(auction[5]).to.equal(3n);
-    expect(auction[8]).to.equal(cipher);
-    expect(auction[9]).to.equal(77n);
+    expect(auction[8]).to.equal(ethers.ZeroHash);
+    expect(auction[9]).to.equal(0n);
+  });
+
+  it("rejects no-winner resolutions that try to assign a non-zero winning amount", async function () {
+    const { market, owner } = await loadFixture(createAuctionFixture);
+
+    await time.increase(24 * 60 * 60 + 1);
+    await market.triggerFinalize(1n);
+
+    await expect(
+      market.connect(owner)["submitResolution(uint256,bytes32,uint256)"](1n, ethers.encodeBytes32String("winner"), 77n)
+    ).to.be.revertedWithCustomError(market, "WinnerRequiredForWinningAmount");
   });
 
   it("rejects resolution calls when the auction is not resolving", async function () {

--- a/packages/contracts/test/unit/SettlementComponents.test.ts
+++ b/packages/contracts/test/unit/SettlementComponents.test.ts
@@ -1,0 +1,108 @@
+import { loadFixture } from "@nomicfoundation/hardhat-network-helpers";
+import { expect } from "chai";
+import { ethers } from "hardhat";
+
+describe("Phase 2 settlement components", function () {
+  async function deployFixture() {
+    const [owner, outsider, recipient] = await ethers.getSigners();
+
+    const settlementEngineFactory = await ethers.getContractFactory("SettlementEngine");
+    const settlementEngine = await settlementEngineFactory.deploy();
+    await settlementEngine.waitForDeployment();
+
+    const slashedPotFactory = await ethers.getContractFactory("SlashedPot");
+    const slashedPot = await slashedPotFactory.deploy(owner.address, await settlementEngine.getAddress());
+    await slashedPot.waitForDeployment();
+
+    const rejectingReceiverFactory = await ethers.getContractFactory("MockRejectingReceiver");
+    const rejectingReceiver = await rejectingReceiverFactory.deploy();
+    await rejectingReceiver.waitForDeployment();
+
+    return {
+      owner,
+      outsider,
+      recipient,
+      settlementEngine,
+      slashedPot,
+      rejectingReceiver
+    };
+  }
+
+  it("covers the timeout, slash, payout, and pro-rata math branches in SettlementEngine", async function () {
+    const { settlementEngine } = await loadFixture(deployFixture);
+
+    expect(await settlementEngine.computeDynamicTimeout(0n)).to.equal(15n * 60n);
+    expect(await settlementEngine.computeDynamicTimeout(1n)).to.equal(15n * 60n);
+    expect(await settlementEngine.computeDynamicTimeout(30n)).to.equal(45n * 60n);
+    expect(await settlementEngine.computeDynamicTimeout(300n)).to.equal(2n * 60n * 60n);
+
+    expect(await settlementEngine.computeCancellationSlash(0n, 10n, 100n, 1n)).to.equal(0n);
+    expect(await settlementEngine.computeCancellationSlash(1000n, 10n, 100n, 0n)).to.equal(0n);
+    expect(await settlementEngine.computeCancellationSlash(1000n, 10n, 0n, 1n)).to.equal(1000n);
+    expect(await settlementEngine.computeCancellationSlash(1000n, 200n, 100n, 1n)).to.equal(1000n);
+
+    expect(await settlementEngine.computeWinningRefund(100n, 100n)).to.equal(0n);
+    expect(await settlementEngine.computeWinningRefund(100n, 150n)).to.equal(0n);
+    expect(await settlementEngine.computeWinningRefund(100n, 60n)).to.equal(40n);
+
+    expect(await settlementEngine.computeSellerPayout(1000n, 400n)).to.equal(1400n);
+    expect(await settlementEngine.computeSellerCancellationPayout(1000n, 1000n)).to.equal(0n);
+    expect(await settlementEngine.computeSellerCancellationPayout(1000n, 250n)).to.equal(750n);
+
+    expect(await settlementEngine.computeProRataShare(0n, 100n, 50n)).to.equal(0n);
+    expect(await settlementEngine.computeProRataShare(10n, 0n, 50n)).to.equal(0n);
+    expect(await settlementEngine.computeProRataShare(10n, 100n, 0n)).to.equal(0n);
+    expect(await settlementEngine.computeProRataShare(25n, 100n, 80n)).to.equal(20n);
+  });
+
+  it("guards SlashedPot setup, access control, and successful pull-based compensation claims", async function () {
+    const { owner, outsider, recipient, settlementEngine } = await loadFixture(deployFixture);
+
+    const slashedPotFactory = await ethers.getContractFactory("SlashedPot");
+    await expect(slashedPotFactory.deploy(owner.address, ethers.ZeroAddress)).to.be.revertedWithCustomError(
+      slashedPotFactory,
+      "ZeroAddress"
+    );
+
+    const slashedPot = await slashedPotFactory.deploy(owner.address, await settlementEngine.getAddress());
+    await slashedPot.waitForDeployment();
+
+    await expect(slashedPot.connect(owner).setMarket(ethers.ZeroAddress)).to.be.revertedWithCustomError(
+      slashedPot,
+      "ZeroAddress"
+    );
+    await expect(slashedPot.connect(outsider).registerSlash(1n, 100n, { value: 10n })).to.be.revertedWithCustomError(
+      slashedPot,
+      "NotMarket"
+    );
+
+    await slashedPot.connect(owner).setMarket(owner.address);
+    await slashedPot.connect(owner).registerSlash(1n, 100n, { value: 30n });
+    await slashedPot.connect(owner).registerSlash(1n, 100n, { value: 20n });
+
+    expect(await slashedPot.previewClaim(1n, 50n)).to.equal(25n);
+    await expect(slashedPot.connect(owner).claimFor(1n, recipient.address, 50n))
+      .to.emit(slashedPot, "CompensationClaimed")
+      .withArgs(1n, recipient.address, 25n);
+    await expect(slashedPot.connect(owner).claimFor(1n, recipient.address, 50n)).to.be.revertedWithCustomError(
+      slashedPot,
+      "CompensationAlreadyClaimed"
+    );
+  });
+
+  it("covers zero-amount claims and transfer failures in SlashedPot", async function () {
+    const { owner, rejectingReceiver, slashedPot } = await loadFixture(deployFixture);
+
+    await slashedPot.connect(owner).setMarket(owner.address);
+    await slashedPot.connect(owner).registerSlash(2n, 100n, { value: 1n });
+
+    expect(await slashedPot.connect(owner).claimFor.staticCall(2n, owner.address, 0n)).to.equal(0n);
+    await slashedPot.connect(owner).claimFor(2n, owner.address, 0n);
+    expect(await slashedPot.hasClaimedCompensation(2n, owner.address)).to.equal(true);
+
+    await slashedPot.connect(owner).registerSlash(3n, 100n, { value: 100n });
+    await expect(
+      slashedPot.connect(owner).claimFor(3n, await rejectingReceiver.getAddress(), 100n)
+    ).to.be.revertedWithCustomError(slashedPot, "NativeTransferFailed");
+  });
+});


### PR DESCRIPTION
﻿## Summary
This PR implements the Phase 2 security and settlement scope on top of the Phase 1 upgradeable auction foundation.

## What Changed
- added encrypted bid placement with `placeBid()` and `ICofheAdapter.lte(...)` escrow checks
- added pull-based bidder refunds, seller proceeds claims, and deferred NFT claims in `FhenixFairMarket`
- added `SettlementEngine.sol` for timeout, slashing, payout, and pro-rata compensation math
- added `SlashedPot.sol` for per-claimant compensation without payout loops
- added `NFTGuard.sol` for escrow custody and terminal asset release helpers
- updated deploy scripts to wire `SettlementEngine` and `SlashedPot`
- added Phase 2 docs and new unit tests for async resolution, dynamic timeout, and settlement components

## Why
Phase 2 is where the market stops being a pure escrow scaffold and becomes economically safe under cancellation, fallback, and encrypted-bid settlement paths.

## Impact
- bidders can now lock escrow, submit encrypted bid handles, and claim refunds individually
- sellers can claim proceeds after finalization or the unslashed remainder after cancellation/void
- fallback void now depends on a moving short-interval network average rather than immediate owner intervention
- compensation for cancellations and voids is escrow-backed and routed through `SlashedPot`

## Validation
- `pnpm compile`
- `pnpm test`
- `pnpm coverage`
- overall coverage: `94.74%` statements, `72.22%` branch, `98.65%` functions, `90.88%` lines
- settlement coverage: `100%` statements, `95.45%` branch, `100%` functions, `100%` lines

## References
Refs #2
Refs #8
Refs #9
Refs #10
Refs #11
