### PR TITLE
[codex] Implement Phase 3 async CoFHE settlement

### DIFF
--- a/docs/phase-3-cofhe-avs.md
+++ b/docs/phase-3-cofhe-avs.md
@@ -1,0 +1,65 @@
+# Phase 3: CoFHE and EigenLayer AVS
+
+## Scope
+
+Phase 3 converts auction finalization from a direct owner-set resolution into an asynchronous settlement flow:
+
+- `triggerFinalize()` now emits a projectable decryption request and moves the auction into `RESOLVING`.
+- The market tracks a pending request id plus synthetic `winnerHandle` / `amountHandle` identifiers.
+- Resolution submission now requires an AVS-backed proof before the auction can move to `FINALIZED`.
+- Invalid or tampered proofs do not finalize the auction and instead trigger symbolic slashing on the mock AVS.
+
+## Contract Changes
+
+### Async request lifecycle
+
+The market contract now exposes:
+
+- `FinalizationTriggered(uint256 auctionId, bytes32 requestId)`
+- `DecryptionRequested(uint256 auctionId, bytes32 requestId, bytes32 winnerHandle, bytes32 amountHandle)`
+- `getResolutionRequest(uint256 auctionId)`
+- `getBidders(uint256 auctionId)`
+
+Bidder addresses are tracked the first time an encrypted bid is submitted so the keeper layer can replay the encrypted orderbook without storing plaintext values on-chain.
+
+### Settlement engine expansion
+
+`SettlementEngine.sol` still owns timeout and payout math, but now also:
+
+- derives deterministic request metadata via `prepareResolutionRequest(...)`
+- delegates AVS proof verification via `verifyResolutionProof(...)`
+- stores the active AVS verifier address with owner-controlled rotation
+
+### Mock EigenLayer AVS
+
+`MockEigenLayerAVS.sol` simulates threshold-attested settlement with:
+
+- operator allowlisting
+- threshold checks
+- ECDSA-based attestations over the settlement digest
+- symbolic slashing when a submitter tries to finalize with a proof envelope that does not match the submitted payload
+
+## Keeper Package
+
+`packages/keeper` now contains three implementation-oriented modules:
+
+- `services/auctionMonitor.ts`: identifies expired auctions and extracts pending request metadata
+- `services/cofheDispatcher.ts`: reconstructs the encrypted orderbook and produces a local CoFHE-style resolution candidate
+- `services/avsSubmitter.ts`: collects threshold signatures from AVS operators and packages the proof envelope
+
+These modules are dependency-light on purpose so the contract integration tests can exercise the same orchestration logic locally.
+
+## Test Coverage
+
+Phase 3 is validated by:
+
+- `test/integration/CoFHEFlow.test.ts`: full end-to-end async path
+- `test/unit/AsyncResolution.test.ts`: valid settlement and tampering rejection
+- updated Phase 1/2 regression suites to use AVS-backed `submitResolution(...)`
+
+The local test matrix now proves:
+
+- `ACTIVE -> RESOLVING -> FINALIZED` state transitions
+- proof-gated settlement acceptance
+- fallback void behavior when no valid resolution arrives
+- symbolic slashing on tampered AVS submissions

--- a/docs/phase-3-cofhe-avs.md
+++ b/docs/phase-3-cofhe-avs.md
@@ -21,6 +21,7 @@ The market contract now exposes:
 - `getBidders(uint256 auctionId)`
 
 Bidder addresses are tracked the first time an encrypted bid is submitted so the keeper layer can replay the encrypted orderbook without storing plaintext values on-chain.
+The new Phase 3 storage is appended after the legacy Phase 2 slots so the UUPS proxy layout remains upgrade-safe.
 
 ### Settlement engine expansion
 
@@ -29,6 +30,7 @@ Bidder addresses are tracked the first time an encrypted bid is submitted so the
 - derives deterministic request metadata via `prepareResolutionRequest(...)`
 - delegates AVS proof verification via `verifyResolutionProof(...)`
 - stores the active AVS verifier address with owner-controlled rotation
+- binds request ids and AVS verification digests to the market address so proofs cannot be replayed across sibling markets that share the same engine or AVS
 
 ### Mock EigenLayer AVS
 

--- a/packages/contracts/contracts/core/FhenixFairMarket.sol
+++ b/packages/contracts/contracts/core/FhenixFairMarket.sol
@@ -49,6 +49,14 @@ contract FhenixFairMarket is
         uint32 bidCount;
     }
 
+    struct PendingResolutionRequest {
+        bool exists;
+        bytes32 requestId;
+        bytes32 winnerHandle;
+        bytes32 amountHandle;
+        uint64 requestedAt;
+    }
+
     error AuctionDoesNotExist(uint256 auctionId);
     error AuctionStillRunning(uint256 auctionId, uint256 endTime);
     error AuctionAlreadyEnded(uint256 auctionId, uint256 endTime);
@@ -59,7 +67,9 @@ contract FhenixFairMarket is
     error BidExceedsEscrow(uint256 auctionId, address bidder);
     error FallbackThresholdNotReached(uint256 elapsed, uint256 requiredThreshold);
     error InvalidWinningAmount(uint256 auctionId, uint256 winningAmount, uint256 availableEscrow);
+    error InvalidAVSProof(uint256 auctionId, bytes32 requestId);
     error MissingEncryptedBid(uint256 auctionId, address bidder);
+    error MissingResolutionRequest(uint256 auctionId);
     error NativeTransferFailed(address recipient, uint256 amount);
     error NoClaimableBalance(uint256 auctionId, address claimant);
     error NoEscrowLocked(uint256 auctionId, address bidder);
@@ -72,6 +82,7 @@ contract FhenixFairMarket is
     error UnexpectedAuctionState(AuctionState expected, AuctionState actual);
     error UnauthorizedAssetClaim(uint256 auctionId, address caller, address expectedRecipient);
     error WinnerRequiredForWinningAmount(uint256 auctionId, uint256 winningAmount);
+    error ResolutionAlreadyRequested(uint256 auctionId, bytes32 requestId);
     error ZeroWinningAmount(uint256 auctionId, address winner);
     error ZeroAddress();
     error ZeroValue();
@@ -87,6 +98,9 @@ contract FhenixFairMarket is
     mapping(uint256 => mapping(address => uint256)) public escrowBalances;
     mapping(uint256 => mapping(address => bool)) public hasWithdrawn;
     mapping(uint256 => mapping(address => bytes32)) private _encryptedBids;
+    mapping(uint256 => mapping(address => bool)) private _knownBidders;
+    mapping(uint256 => address[]) private _bidders;
+    mapping(uint256 => PendingResolutionRequest) private _resolutionRequests;
 
     uint256 public auctionCounter;
     uint256 private _reentrancyStatus;
@@ -109,11 +123,19 @@ contract FhenixFairMarket is
     event BidPlaced(uint256 indexed auctionId, address indexed bidder, bytes32 bidHandle);
     event EscrowLocked(uint256 indexed auctionId, address indexed bidder, uint256 amount);
     event ResolutionRecorded(uint256 indexed auctionId, address indexed winner, bytes32 winnerCiphertext);
+    event ResolutionRejected(uint256 indexed auctionId, bytes32 indexed requestId);
     event RefundClaimed(uint256 indexed auctionId, address indexed claimant, uint256 escrowRefund, uint256 compensation);
     event SellerProceedsClaimed(uint256 indexed auctionId, address indexed seller, uint256 amount);
     event AssetClaimed(uint256 indexed auctionId, address indexed recipient, uint256 tokenId);
     event SettlementDependenciesUpdated(address indexed settlementEngine, address indexed slashedPot);
     event FallbackTriggered(uint256 indexed auctionId, uint256 elapsed, uint256 threshold);
+    event FinalizationTriggered(uint256 indexed auctionId, bytes32 indexed requestId);
+    event DecryptionRequested(
+        uint256 indexed auctionId,
+        bytes32 indexed requestId,
+        bytes32 winnerHandle,
+        bytes32 amountHandle
+    );
 
     modifier auctionExists(uint256 auctionId) {
         if (!_auctions[auctionId].exists) {
@@ -160,7 +182,7 @@ contract FhenixFairMarket is
     }
 
     function contractVersion() public pure virtual returns (string memory) {
-        return "phase2";
+        return "phase3";
     }
 
     function setSettlementEngine(ISettlementEngine newSettlementEngine) external onlyOwner {
@@ -281,6 +303,10 @@ contract FhenixFairMarket is
         if (_encryptedBids[auctionId][msg.sender] == bytes32(0)) {
             auction.bidCount += 1;
         }
+        if (!_knownBidders[auctionId][msg.sender]) {
+            _knownBidders[auctionId][msg.sender] = true;
+            _bidders[auctionId].push(msg.sender);
+        }
 
         _encryptedBids[auctionId][msg.sender] = encryptedBid;
         auction.lastBlockTimestamp = uint64(block.timestamp);
@@ -294,30 +320,50 @@ contract FhenixFairMarket is
         auctionExists(auctionId)
         onlyAuctionState(auctionId, AuctionState.ACTIVE)
     {
-        if (block.timestamp < _auctions[auctionId].endTime) {
-            revert AuctionStillRunning(auctionId, _auctions[auctionId].endTime);
+        Auction storage auction = _auctions[auctionId];
+        if (block.timestamp < auction.endTime) {
+            revert AuctionStillRunning(auctionId, auction.endTime);
+        }
+
+        PendingResolutionRequest storage existingRequest = _resolutionRequests[auctionId];
+        if (existingRequest.exists) {
+            revert ResolutionAlreadyRequested(auctionId, existingRequest.requestId);
         }
 
         _observeNetwork();
         _transitionState(auctionId, AuctionState.RESOLVING);
-        _auctions[auctionId].resolvingSince = uint64(block.timestamp);
+        auction.resolvingSince = uint64(block.timestamp);
+
+        ISettlementEngine.ResolutionRequest memory nextRequest = _prepareResolutionRequest(auctionId, auction);
+        _resolutionRequests[auctionId] = PendingResolutionRequest({
+            exists: true,
+            requestId: nextRequest.requestId,
+            winnerHandle: nextRequest.winnerHandle,
+            amountHandle: nextRequest.amountHandle,
+            requestedAt: uint64(block.timestamp)
+        });
+
+        emit FinalizationTriggered(auctionId, nextRequest.requestId);
+        emit DecryptionRequested(auctionId, nextRequest.requestId, nextRequest.winnerHandle, nextRequest.amountHandle);
     }
 
     function submitResolution(
         uint256 auctionId,
         bytes32 winnerCiphertext,
-        uint256 winningAmount
-    ) external onlyOwner auctionExists(auctionId) onlyAuctionState(auctionId, AuctionState.RESOLVING) {
-        _submitResolution(auctionId, address(0), winnerCiphertext, winningAmount);
+        uint256 winningAmount,
+        bytes calldata avsProof
+    ) external onlyOwner auctionExists(auctionId) onlyAuctionState(auctionId, AuctionState.RESOLVING) returns (bool) {
+        return _submitResolution(auctionId, address(0), winnerCiphertext, winningAmount, avsProof);
     }
 
     function submitResolution(
         uint256 auctionId,
         address winner,
         bytes32 winnerCiphertext,
-        uint256 winningAmount
-    ) external onlyOwner auctionExists(auctionId) onlyAuctionState(auctionId, AuctionState.RESOLVING) {
-        _submitResolution(auctionId, winner, winnerCiphertext, winningAmount);
+        uint256 winningAmount,
+        bytes calldata avsProof
+    ) external onlyOwner auctionExists(auctionId) onlyAuctionState(auctionId, AuctionState.RESOLVING) returns (bool) {
+        return _submitResolution(auctionId, winner, winnerCiphertext, winningAmount, avsProof);
     }
 
     function cancelAuction(uint256 auctionId)
@@ -357,6 +403,7 @@ contract FhenixFairMarket is
         auction.slashAmount = auction.totalEscrow == 0 ? 0 : auction.sellerDeposit;
         _registerSlash(auctionId, auction.totalEscrow, auction.slashAmount);
         _observeNetwork();
+        delete _resolutionRequests[auctionId];
 
         NFTGuard.releaseFromEscrow(auction.nftContract, address(this), auction.seller, auction.tokenId);
         _transitionState(auctionId, AuctionState.VOIDED);
@@ -495,6 +542,24 @@ contract FhenixFairMarket is
         return _encryptedBids[auctionId][bidder];
     }
 
+    function getBidders(uint256 auctionId) external view auctionExists(auctionId) returns (address[] memory) {
+        return _bidders[auctionId];
+    }
+
+    function getResolutionRequest(uint256 auctionId)
+        external
+        view
+        auctionExists(auctionId)
+        returns (bytes32 requestId, bytes32 winnerHandle, bytes32 amountHandle, uint64 requestedAt)
+    {
+        PendingResolutionRequest storage request = _resolutionRequests[auctionId];
+        if (!request.exists) {
+            revert MissingResolutionRequest(auctionId);
+        }
+
+        return (request.requestId, request.winnerHandle, request.amountHandle, request.requestedAt);
+    }
+
     function previewDynamicTimeout() public view returns (uint256) {
         if (address(settlementEngine) == address(0)) {
             return _DEFAULT_DYNAMIC_TIMEOUT;
@@ -554,8 +619,23 @@ contract FhenixFairMarket is
 
     function _authorizeUpgrade(address) internal override onlyOwner {}
 
-    function _submitResolution(uint256 auctionId, address winner, bytes32 winnerCiphertext, uint256 winningAmount) internal {
+    function _submitResolution(
+        uint256 auctionId,
+        address winner,
+        bytes32 winnerCiphertext,
+        uint256 winningAmount,
+        bytes calldata avsProof
+    ) internal returns (bool) {
         Auction storage auction = _auctions[auctionId];
+        PendingResolutionRequest storage request = _resolutionRequests[auctionId];
+        if (!request.exists) {
+            revert MissingResolutionRequest(auctionId);
+        }
+
+        if (address(settlementEngine) == address(0)) {
+            revert InvalidAVSProof(auctionId, request.requestId);
+        }
+
         if (winner == address(0)) {
             if (winningAmount != 0) {
                 revert WinnerRequiredForWinningAmount(auctionId, winningAmount);
@@ -575,13 +655,49 @@ contract FhenixFairMarket is
             }
         }
 
+        if (
+            !settlementEngine.verifyResolutionProof(
+                auctionId,
+                request.requestId,
+                winner,
+                winnerCiphertext,
+                winningAmount,
+                avsProof
+            )
+        ) {
+            emit ResolutionRejected(auctionId, request.requestId);
+            return false;
+        }
+
         auction.winner = winner;
         auction.winnerCiphertext = winnerCiphertext;
         auction.winningAmount = winningAmount;
+        delete _resolutionRequests[auctionId];
         _observeNetwork();
 
         _transitionState(auctionId, AuctionState.FINALIZED);
         emit ResolutionRecorded(auctionId, winner, winnerCiphertext);
+        return true;
+    }
+
+    function _prepareResolutionRequest(uint256 auctionId, Auction storage auction)
+        internal
+        view
+        returns (ISettlementEngine.ResolutionRequest memory)
+    {
+        if (address(settlementEngine) == address(0)) {
+            bytes32 requestId = keccak256(
+                abi.encode(address(this), block.chainid, auctionId, auction.bidCount, auction.endTime)
+            );
+            return
+                ISettlementEngine.ResolutionRequest({
+                    requestId: requestId,
+                    winnerHandle: keccak256(abi.encode(requestId, "winner")),
+                    amountHandle: keccak256(abi.encode(requestId, "amount"))
+                });
+        }
+
+        return settlementEngine.prepareResolutionRequest(auctionId, auction.bidCount, auction.endTime);
     }
 
     function _observeNetwork() internal {

--- a/packages/contracts/contracts/core/FhenixFairMarket.sol
+++ b/packages/contracts/contracts/core/FhenixFairMarket.sol
@@ -98,9 +98,6 @@ contract FhenixFairMarket is
     mapping(uint256 => mapping(address => uint256)) public escrowBalances;
     mapping(uint256 => mapping(address => bool)) public hasWithdrawn;
     mapping(uint256 => mapping(address => bytes32)) private _encryptedBids;
-    mapping(uint256 => mapping(address => bool)) private _knownBidders;
-    mapping(uint256 => address[]) private _bidders;
-    mapping(uint256 => PendingResolutionRequest) private _resolutionRequests;
 
     uint256 public auctionCounter;
     uint256 private _reentrancyStatus;
@@ -109,6 +106,10 @@ contract FhenixFairMarket is
     ISettlementEngine public settlementEngine;
     uint64 public lastObservationTimestamp;
     uint64 public movingAverageBlockDelta;
+    // New Phase 3 storage must stay append-only to preserve the Phase 2 proxy layout.
+    mapping(uint256 => mapping(address => bool)) private _knownBidders;
+    mapping(uint256 => address[]) private _bidders;
+    mapping(uint256 => PendingResolutionRequest) private _resolutionRequests;
 
     event AuctionCreated(
         uint256 indexed auctionId,
@@ -657,6 +658,7 @@ contract FhenixFairMarket is
 
         if (
             !settlementEngine.verifyResolutionProof(
+                address(this),
                 auctionId,
                 request.requestId,
                 winner,
@@ -697,7 +699,7 @@ contract FhenixFairMarket is
                 });
         }
 
-        return settlementEngine.prepareResolutionRequest(auctionId, auction.bidCount, auction.endTime);
+        return settlementEngine.prepareResolutionRequest(address(this), auctionId, auction.bidCount, auction.endTime);
     }
 
     function _observeNetwork() internal {

--- a/packages/contracts/contracts/interfaces/IEigenLayerAVS.sol
+++ b/packages/contracts/contracts/interfaces/IEigenLayerAVS.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.25;
 
 interface IEigenLayerAVS {
     function computeDigest(
+        address market,
         uint256 auctionId,
         bytes32 requestId,
         address winner,
@@ -11,6 +12,7 @@ interface IEigenLayerAVS {
     ) external view returns (bytes32);
 
     function verifyAttestation(
+        address market,
         uint256 auctionId,
         bytes32 requestId,
         address winner,

--- a/packages/contracts/contracts/interfaces/IEigenLayerAVS.sol
+++ b/packages/contracts/contracts/interfaces/IEigenLayerAVS.sol
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+interface IEigenLayerAVS {
+    function computeDigest(
+        uint256 auctionId,
+        bytes32 requestId,
+        address winner,
+        bytes32 winnerCiphertext,
+        uint256 winningAmount
+    ) external view returns (bytes32);
+
+    function verifyAttestation(
+        uint256 auctionId,
+        bytes32 requestId,
+        address winner,
+        bytes32 winnerCiphertext,
+        uint256 winningAmount,
+        bytes calldata proof
+    ) external returns (bool);
+}

--- a/packages/contracts/contracts/interfaces/ISettlementEngine.sol
+++ b/packages/contracts/contracts/interfaces/ISettlementEngine.sol
@@ -2,6 +2,12 @@
 pragma solidity ^0.8.25;
 
 interface ISettlementEngine {
+    struct ResolutionRequest {
+        bytes32 requestId;
+        bytes32 winnerHandle;
+        bytes32 amountHandle;
+    }
+
     function computeDynamicTimeout(uint256 movingAverageBlockDelta) external pure returns (uint256);
 
     function computeCancellationSlash(
@@ -22,4 +28,19 @@ interface ISettlementEngine {
         uint256 totalEscrow,
         uint256 totalPot
     ) external pure returns (uint256);
+
+    function prepareResolutionRequest(
+        uint256 auctionId,
+        uint32 bidCount,
+        uint64 endTime
+    ) external view returns (ResolutionRequest memory);
+
+    function verifyResolutionProof(
+        uint256 auctionId,
+        bytes32 requestId,
+        address winner,
+        bytes32 winnerCiphertext,
+        uint256 winningAmount,
+        bytes calldata avsProof
+    ) external returns (bool);
 }

--- a/packages/contracts/contracts/interfaces/ISettlementEngine.sol
+++ b/packages/contracts/contracts/interfaces/ISettlementEngine.sol
@@ -30,12 +30,14 @@ interface ISettlementEngine {
     ) external pure returns (uint256);
 
     function prepareResolutionRequest(
+        address market,
         uint256 auctionId,
         uint32 bidCount,
         uint64 endTime
     ) external view returns (ResolutionRequest memory);
 
     function verifyResolutionProof(
+        address market,
         uint256 auctionId,
         bytes32 requestId,
         address winner,

--- a/packages/contracts/contracts/mocks/MockEigenLayerAVS.sol
+++ b/packages/contracts/contracts/mocks/MockEigenLayerAVS.sol
@@ -1,0 +1,199 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+import "@openzeppelin/contracts/access/Ownable.sol";
+import "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
+import "@openzeppelin/contracts/utils/cryptography/MessageHashUtils.sol";
+
+import "../interfaces/IEigenLayerAVS.sol";
+
+contract MockEigenLayerAVS is Ownable, IEigenLayerAVS {
+    using ECDSA for bytes32;
+    using MessageHashUtils for bytes32;
+
+    struct ProofEnvelope {
+        uint256 auctionId;
+        bytes32 requestId;
+        address winner;
+        bytes32 winnerCiphertext;
+        uint256 winningAmount;
+        address[] operators;
+        bytes[] signatures;
+    }
+
+    error DuplicateOperator(address operator);
+    error InvalidOperator(address operator);
+    error InvalidThreshold(uint256 threshold, uint256 operatorCount);
+    error ProofLengthMismatch(uint256 operatorsLength, uint256 signaturesLength);
+    error ZeroAddress();
+
+    mapping(address => bool) public isOperator;
+    mapping(address => uint256) public slashCount;
+
+    uint256 public operatorCount;
+    uint256 public threshold;
+
+    event AttestationVerified(
+        uint256 indexed auctionId,
+        bytes32 indexed requestId,
+        address indexed winner,
+        uint256 winningAmount,
+        uint256 signerCount
+    );
+    event OperatorSet(address indexed operator, bool allowed);
+    event OperatorSlashed(bytes32 indexed requestId, address indexed operator);
+    event ThresholdUpdated(uint256 previousThreshold, uint256 newThreshold);
+
+    constructor(address initialOwner, address[] memory initialOperators, uint256 initialThreshold) Ownable(initialOwner) {
+        if (initialOperators.length == 0) {
+            revert InvalidThreshold(initialThreshold, 0);
+        }
+
+        for (uint256 index = 0; index < initialOperators.length; ++index) {
+            address operator = initialOperators[index];
+            if (operator == address(0)) {
+                revert ZeroAddress();
+            }
+            if (isOperator[operator]) {
+                revert DuplicateOperator(operator);
+            }
+
+            isOperator[operator] = true;
+            operatorCount += 1;
+            emit OperatorSet(operator, true);
+        }
+
+        _setThreshold(initialThreshold);
+    }
+
+    function setOperator(address operator, bool allowed) external onlyOwner {
+        if (operator == address(0)) {
+            revert ZeroAddress();
+        }
+
+        if (allowed && isOperator[operator]) {
+            revert DuplicateOperator(operator);
+        }
+        if (!allowed && !isOperator[operator]) {
+            revert InvalidOperator(operator);
+        }
+
+        isOperator[operator] = allowed;
+        operatorCount = allowed ? operatorCount + 1 : operatorCount - 1;
+        emit OperatorSet(operator, allowed);
+
+        if (threshold > operatorCount) {
+            _setThreshold(operatorCount);
+        }
+    }
+
+    function setThreshold(uint256 newThreshold) external onlyOwner {
+        _setThreshold(newThreshold);
+    }
+
+    function computeDigest(
+        uint256 auctionId,
+        bytes32 requestId,
+        address winner,
+        bytes32 winnerCiphertext,
+        uint256 winningAmount
+    ) public view override returns (bytes32) {
+        return keccak256(
+            abi.encode(address(this), block.chainid, auctionId, requestId, winner, winnerCiphertext, winningAmount)
+        );
+    }
+
+    function verifyAttestation(
+        uint256 auctionId,
+        bytes32 requestId,
+        address winner,
+        bytes32 winnerCiphertext,
+        uint256 winningAmount,
+        bytes calldata proof
+    ) external override returns (bool) {
+        ProofEnvelope memory envelope = abi.decode(proof, (ProofEnvelope));
+        if (envelope.operators.length != envelope.signatures.length) {
+            revert ProofLengthMismatch(envelope.operators.length, envelope.signatures.length);
+        }
+
+        if (
+            envelope.auctionId != auctionId ||
+            envelope.requestId != requestId ||
+            envelope.winner != winner ||
+            envelope.winnerCiphertext != winnerCiphertext ||
+            envelope.winningAmount != winningAmount
+        ) {
+            _slashOperators(requestId, envelope.operators);
+            return false;
+        }
+
+        if (envelope.operators.length < threshold) {
+            return false;
+        }
+
+        bytes32 digest = computeDigest(auctionId, requestId, winner, winnerCiphertext, winningAmount).toEthSignedMessageHash();
+        uint256 validSignatures = 0;
+
+        for (uint256 index = 0; index < envelope.operators.length; ++index) {
+            address expectedOperator = envelope.operators[index];
+            if (!isOperator[expectedOperator]) {
+                _slashOperators(requestId, envelope.operators);
+                return false;
+            }
+
+            for (uint256 prior = 0; prior < index; ++prior) {
+                if (expectedOperator == envelope.operators[prior]) {
+                    _slashOperators(requestId, envelope.operators);
+                    return false;
+                }
+            }
+
+            address recoveredSigner = digest.recover(envelope.signatures[index]);
+            if (recoveredSigner != expectedOperator) {
+                _slashOperators(requestId, envelope.operators);
+                return false;
+            }
+
+            validSignatures += 1;
+        }
+
+        if (validSignatures < threshold) {
+            return false;
+        }
+
+        emit AttestationVerified(auctionId, requestId, winner, winningAmount, validSignatures);
+        return true;
+    }
+
+    function _setThreshold(uint256 newThreshold) internal {
+        if (newThreshold == 0 || newThreshold > operatorCount) {
+            revert InvalidThreshold(newThreshold, operatorCount);
+        }
+
+        uint256 previousThreshold = threshold;
+        threshold = newThreshold;
+        emit ThresholdUpdated(previousThreshold, newThreshold);
+    }
+
+    function _slashOperators(bytes32 requestId, address[] memory operators) internal {
+        for (uint256 index = 0; index < operators.length; ++index) {
+            address operator = operators[index];
+            if (!isOperator[operator] || _contains(operators, operator, index)) {
+                continue;
+            }
+
+            slashCount[operator] += 1;
+            emit OperatorSlashed(requestId, operator);
+        }
+    }
+
+    function _contains(address[] memory operators, address operator, uint256 currentIndex) private pure returns (bool) {
+        for (uint256 index = 0; index < currentIndex; ++index) {
+            if (operators[index] == operator) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/packages/contracts/contracts/mocks/MockEigenLayerAVS.sol
+++ b/packages/contracts/contracts/mocks/MockEigenLayerAVS.sol
@@ -92,18 +92,24 @@ contract MockEigenLayerAVS is Ownable, IEigenLayerAVS {
     }
 
     function computeDigest(
+        address market,
         uint256 auctionId,
         bytes32 requestId,
         address winner,
         bytes32 winnerCiphertext,
         uint256 winningAmount
     ) public view override returns (bytes32) {
+        if (market == address(0)) {
+            revert ZeroAddress();
+        }
+
         return keccak256(
-            abi.encode(address(this), block.chainid, auctionId, requestId, winner, winnerCiphertext, winningAmount)
+            abi.encode(address(this), block.chainid, market, auctionId, requestId, winner, winnerCiphertext, winningAmount)
         );
     }
 
     function verifyAttestation(
+        address market,
         uint256 auctionId,
         bytes32 requestId,
         address winner,
@@ -131,7 +137,8 @@ contract MockEigenLayerAVS is Ownable, IEigenLayerAVS {
             return false;
         }
 
-        bytes32 digest = computeDigest(auctionId, requestId, winner, winnerCiphertext, winningAmount).toEthSignedMessageHash();
+        bytes32 digest = computeDigest(market, auctionId, requestId, winner, winnerCiphertext, winningAmount)
+            .toEthSignedMessageHash();
         uint256 validSignatures = 0;
 
         for (uint256 index = 0; index < envelope.operators.length; ++index) {

--- a/packages/contracts/contracts/settlement/SettlementEngine.sol
+++ b/packages/contracts/contracts/settlement/SettlementEngine.sol
@@ -107,11 +107,16 @@ contract SettlementEngine is Ownable, ISettlementEngine {
     }
 
     function prepareResolutionRequest(
+        address market,
         uint256 auctionId,
         uint32 bidCount,
         uint64 endTime
     ) external view override returns (ResolutionRequest memory) {
-        bytes32 requestId = keccak256(abi.encode(address(this), block.chainid, auctionId, bidCount, endTime));
+        if (market == address(0)) {
+            revert ZeroAddress();
+        }
+
+        bytes32 requestId = keccak256(abi.encode(address(this), block.chainid, market, auctionId, bidCount, endTime));
         return
             ResolutionRequest({
                 requestId: requestId,
@@ -121,6 +126,7 @@ contract SettlementEngine is Ownable, ISettlementEngine {
     }
 
     function verifyResolutionProof(
+        address market,
         uint256 auctionId,
         bytes32 requestId,
         address winner,
@@ -128,10 +134,10 @@ contract SettlementEngine is Ownable, ISettlementEngine {
         uint256 winningAmount,
         bytes calldata avsProof
     ) external override returns (bool) {
-        if (address(avs) == address(0)) {
+        if (market == address(0) || address(avs) == address(0)) {
             revert ZeroAddress();
         }
 
-        return avs.verifyAttestation(auctionId, requestId, winner, winnerCiphertext, winningAmount, avsProof);
+        return avs.verifyAttestation(market, auctionId, requestId, winner, winnerCiphertext, winningAmount, avsProof);
     }
 }

--- a/packages/contracts/contracts/settlement/SettlementEngine.sol
+++ b/packages/contracts/contracts/settlement/SettlementEngine.sol
@@ -1,14 +1,35 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.25;
 
+import "@openzeppelin/contracts/access/Ownable.sol";
+
+import "../interfaces/IEigenLayerAVS.sol";
 import "../interfaces/ISettlementEngine.sol";
 
-contract SettlementEngine is ISettlementEngine {
+contract SettlementEngine is Ownable, ISettlementEngine {
     uint256 public constant BPS_DENOMINATOR = 10_000;
     uint256 public constant MIN_DYNAMIC_TIMEOUT = 15 minutes;
     uint256 public constant MAX_DYNAMIC_TIMEOUT = 2 hours;
     uint256 public constant DYNAMIC_TIMEOUT_MULTIPLIER = 90;
     uint256 public constant MIN_CANCELLATION_SLASH_BPS = 2_500;
+
+    error ZeroAddress();
+
+    IEigenLayerAVS public avs;
+
+    event AVSUpdated(address indexed previousAVS, address indexed newAVS);
+
+    constructor(address initialOwner) Ownable(initialOwner) {}
+
+    function setAVS(IEigenLayerAVS newAVS) external onlyOwner {
+        if (address(newAVS) == address(0)) {
+            revert ZeroAddress();
+        }
+
+        address previousAVS = address(avs);
+        avs = newAVS;
+        emit AVSUpdated(previousAVS, address(newAVS));
+    }
 
     function computeDynamicTimeout(uint256 movingAverageBlockDelta) external pure override returns (uint256) {
         uint256 timeoutWindow = movingAverageBlockDelta == 0
@@ -83,5 +104,34 @@ contract SettlementEngine is ISettlementEngine {
         }
 
         return (contribution * totalPot) / totalEscrow;
+    }
+
+    function prepareResolutionRequest(
+        uint256 auctionId,
+        uint32 bidCount,
+        uint64 endTime
+    ) external view override returns (ResolutionRequest memory) {
+        bytes32 requestId = keccak256(abi.encode(address(this), block.chainid, auctionId, bidCount, endTime));
+        return
+            ResolutionRequest({
+                requestId: requestId,
+                winnerHandle: keccak256(abi.encode(requestId, "winner")),
+                amountHandle: keccak256(abi.encode(requestId, "amount"))
+            });
+    }
+
+    function verifyResolutionProof(
+        uint256 auctionId,
+        bytes32 requestId,
+        address winner,
+        bytes32 winnerCiphertext,
+        uint256 winningAmount,
+        bytes calldata avsProof
+    ) external override returns (bool) {
+        if (address(avs) == address(0)) {
+            revert ZeroAddress();
+        }
+
+        return avs.verifyAttestation(auctionId, requestId, winner, winnerCiphertext, winningAmount, avsProof);
     }
 }

--- a/packages/contracts/deploy/01_deploy_core_proxy.ts
+++ b/packages/contracts/deploy/01_deploy_core_proxy.ts
@@ -36,6 +36,14 @@ async function main() {
 
   const [defaultSigner] = await ethers.getSigners();
   const initialOwner = process.env.PHASE1_INITIAL_OWNER || defaultSigner.address;
+  let avsAddress = process.env.PHASE3_AVS || existing.avs;
+  if (avsAddress) {
+    const deployedCode = await ethers.provider.getCode(avsAddress);
+    if (deployedCode === "0x") {
+      avsAddress = undefined;
+    }
+  }
+
   let settlementEngineAddress = process.env.PHASE2_SETTLEMENT_ENGINE || existing.settlementEngine;
   if (settlementEngineAddress) {
     const deployedCode = await ethers.provider.getCode(settlementEngineAddress);
@@ -46,9 +54,16 @@ async function main() {
 
   if (!settlementEngineAddress) {
     const settlementEngineFactory = await ethers.getContractFactory("SettlementEngine");
-    const settlementEngine = await settlementEngineFactory.deploy();
+    const settlementEngine = await settlementEngineFactory.deploy(initialOwner);
     await settlementEngine.waitForDeployment();
     settlementEngineAddress = await settlementEngine.getAddress();
+  }
+
+  if (!avsAddress) {
+    const avsFactory = await ethers.getContractFactory("MockEigenLayerAVS");
+    const avs = await avsFactory.deploy(initialOwner, [defaultSigner.address], 1);
+    await avs.waitForDeployment();
+    avsAddress = await avs.getAddress();
   }
 
   let slashedPot = process.env.PHASE1_SLASHED_POT || existing.slashedPot;
@@ -92,9 +107,16 @@ async function main() {
     await (await market.connect(defaultSigner).setSettlementEngine(settlementEngineAddress)).wait();
   }
 
+  const settlementEngineFactory = await ethers.getContractFactory("SettlementEngine");
+  const settlementEngine = settlementEngineFactory.attach(settlementEngineAddress);
+  if ((await settlementEngine.avs()) != avsAddress) {
+    await (await settlementEngine.connect(defaultSigner).setAVS(avsAddress)).wait();
+  }
+
   const nextPayload = {
     ...existing,
     adapter: adapterAddress,
+    avs: avsAddress,
     settlementEngine: settlementEngineAddress,
     implementation: await implementation.getAddress(),
     proxy: await proxy.getAddress(),
@@ -108,6 +130,7 @@ async function main() {
   console.log(`Proxy deployed to ${nextPayload.proxy}`);
   console.log(`SlashedPot deployed to ${nextPayload.slashedPot}`);
   console.log(`SettlementEngine configured at ${nextPayload.settlementEngine}`);
+  console.log(`Mock AVS configured at ${nextPayload.avs}`);
 }
 
 main().catch((error) => {

--- a/packages/contracts/test/helpers/fixtures.ts
+++ b/packages/contracts/test/helpers/fixtures.ts
@@ -1,19 +1,28 @@
 import { ethers } from "hardhat";
 
 export async function deployPhase2Fixture() {
-  const [owner, seller, bidder, bidderTwo, outsider] = await ethers.getSigners();
+  const [owner, seller, bidder, bidderTwo, outsider, avsOperatorOne, avsOperatorTwo, avsOperatorThree] =
+    await ethers.getSigners();
 
   const adapterFactory = await ethers.getContractFactory("CofheAdapter");
   const adapter = await adapterFactory.deploy();
   await adapter.waitForDeployment();
 
   const settlementEngineFactory = await ethers.getContractFactory("SettlementEngine");
-  const settlementEngine = await settlementEngineFactory.deploy();
+  const settlementEngine = await settlementEngineFactory.deploy(owner.address);
   await settlementEngine.waitForDeployment();
 
   const slashedPotFactory = await ethers.getContractFactory("SlashedPot");
   const slashedPot = await slashedPotFactory.deploy(owner.address, await settlementEngine.getAddress());
   await slashedPot.waitForDeployment();
+
+  const avsFactory = await ethers.getContractFactory("MockEigenLayerAVS");
+  const avs = await avsFactory.deploy(
+    owner.address,
+    [avsOperatorOne.address, avsOperatorTwo.address, avsOperatorThree.address],
+    2
+  );
+  await avs.waitForDeployment();
 
   const implementationFactory = await ethers.getContractFactory("FhenixFairMarket");
   const implementation = await implementationFactory.deploy();
@@ -31,6 +40,7 @@ export async function deployPhase2Fixture() {
 
   const market = implementationFactory.attach(await proxy.getAddress());
   await market.connect(owner).setSettlementEngine(await settlementEngine.getAddress());
+  await settlementEngine.connect(owner).setAVS(await avs.getAddress());
   await slashedPot.connect(owner).setMarket(await market.getAddress());
 
   const nftFactory = await ethers.getContractFactory("MockERC721");
@@ -47,6 +57,10 @@ export async function deployPhase2Fixture() {
     bidder,
     bidderTwo,
     outsider,
+    avs,
+    avsOperatorOne,
+    avsOperatorTwo,
+    avsOperatorThree,
     adapter,
     settlementEngine,
     slashedPot,

--- a/packages/contracts/test/helpers/phase3.ts
+++ b/packages/contracts/test/helpers/phase3.ts
@@ -1,0 +1,107 @@
+import { AbiCoder, getBytes, type Signer } from "ethers";
+
+import { AuctionMonitor } from "../../../keeper/services/auctionMonitor";
+import { AvsSubmitter } from "../../../keeper/services/avsSubmitter";
+import { CofheDispatcher, type EncryptedBidRecord } from "../../../keeper/services/cofheDispatcher";
+
+export async function collectEncryptedBids(
+  market: {
+    getBidders(auctionId: bigint): Promise<readonly string[]>;
+    getEncryptedBid(auctionId: bigint, bidder: string): Promise<string>;
+    escrowBalances(auctionId: bigint, bidder: string): Promise<bigint>;
+  },
+  auctionId: bigint
+): Promise<EncryptedBidRecord[]> {
+  const bidders = await market.getBidders(auctionId);
+  const bids: EncryptedBidRecord[] = [];
+
+  for (const bidder of bidders) {
+    bids.push({
+      bidder,
+      encryptedBid: await market.getEncryptedBid(auctionId, bidder),
+      availableEscrow: await market.escrowBalances(auctionId, bidder)
+    });
+  }
+
+  return bids;
+}
+
+export async function buildPhase3ResolutionProof(
+  market: {
+    getResolutionRequest(auctionId: bigint): Promise<readonly [string, string, string, bigint]>;
+    getAuction(auctionId: bigint): Promise<readonly unknown[]>;
+  },
+  avs: {
+    computeDigest(
+      auctionId: bigint,
+      requestId: string,
+      winner: string,
+      winnerCiphertext: string,
+      winningAmount: bigint
+    ): Promise<string>;
+  },
+  auctionId: bigint,
+  bidders: EncryptedBidRecord[],
+  operators: readonly Signer[]
+) {
+  const monitor = new AuctionMonitor(market);
+  const request = await monitor.inspectTriggeredAuction(auctionId);
+  const dispatcher = new CofheDispatcher();
+  const resolution = await dispatcher.dispatch({
+    auctionId,
+    requestId: request.requestId,
+    winnerHandle: request.winnerHandle,
+    amountHandle: request.amountHandle,
+    bids: bidders
+  });
+
+  const payload = {
+    auctionId,
+    requestId: request.requestId,
+    winner: resolution.winner ?? "0x0000000000000000000000000000000000000000",
+    winnerCiphertext: resolution.winnerCiphertext,
+    winningAmount: resolution.winningAmount
+  };
+
+  const digest = await avs.computeDigest(
+    payload.auctionId,
+    payload.requestId,
+    payload.winner,
+    payload.winnerCiphertext,
+    payload.winningAmount
+  );
+
+  const submitter = new AvsSubmitter(2);
+  const proofEnvelope = await submitter.collectProof(
+    payload,
+    digest,
+    operators.map((operator) => ({
+      address: (operator as unknown as { address: string }).address,
+      signDigest: async (requestedDigest: string) => operator.signMessage(getBytes(requestedDigest))
+    }))
+  );
+
+  const proof = AbiCoder.defaultAbiCoder().encode(
+    [
+      "tuple(uint256 auctionId, bytes32 requestId, address winner, bytes32 winnerCiphertext, uint256 winningAmount, address[] operators, bytes[] signatures)"
+    ],
+    [
+      [
+        proofEnvelope.auctionId,
+        proofEnvelope.requestId,
+        proofEnvelope.winner,
+        proofEnvelope.winnerCiphertext,
+        proofEnvelope.winningAmount,
+        proofEnvelope.operators,
+        proofEnvelope.signatures
+      ]
+    ]
+  );
+
+  return {
+    request,
+    resolution,
+    payload,
+    proof
+  };
+}

--- a/packages/contracts/test/helpers/phase3.ts
+++ b/packages/contracts/test/helpers/phase3.ts
@@ -28,11 +28,13 @@ export async function collectEncryptedBids(
 
 export async function buildPhase3ResolutionProof(
   market: {
+    getAddress(): Promise<string>;
     getResolutionRequest(auctionId: bigint): Promise<readonly [string, string, string, bigint]>;
     getAuction(auctionId: bigint): Promise<readonly unknown[]>;
   },
   avs: {
     computeDigest(
+      market: string,
       auctionId: bigint,
       requestId: string,
       winner: string,
@@ -64,6 +66,7 @@ export async function buildPhase3ResolutionProof(
   };
 
   const digest = await avs.computeDigest(
+    await market.getAddress(),
     payload.auctionId,
     payload.requestId,
     payload.winner,

--- a/packages/contracts/test/integration/CoFHEFlow.test.ts
+++ b/packages/contracts/test/integration/CoFHEFlow.test.ts
@@ -1,0 +1,81 @@
+import { loadFixture, time } from "@nomicfoundation/hardhat-network-helpers";
+import { expect } from "chai";
+import { ethers } from "hardhat";
+
+import { createPhase2AuctionFixture } from "../helpers/fixtures";
+import { buildPhase3ResolutionProof, collectEncryptedBids } from "../helpers/phase3";
+
+describe("Phase 3 CoFHE and AVS integration flow", function () {
+  it("runs the full async flow from encrypted bidding through AVS-backed settlement", async function () {
+    const { adapter, avs, avsOperatorOne, avsOperatorTwo, bidder, bidderTwo, market, nft, owner, seller } =
+      await loadFixture(createPhase2AuctionFixture);
+
+    await market.connect(bidder).lockEscrow(1n, { value: 600n });
+    await market.connect(bidderTwo).lockEscrow(1n, { value: 500n });
+
+    const winningBid = await adapter.asEuint32(450);
+    const losingBid = await adapter.asEuint32(420);
+    await market.connect(bidder).placeBid(1n, winningBid);
+    await market.connect(bidderTwo).placeBid(1n, losingBid);
+
+    const bidders = await market.getBidders(1n);
+    expect(bidders).to.deep.equal([bidder.address, bidderTwo.address]);
+
+    await time.increase(24 * 60 * 60 + 1);
+
+    await expect(market.triggerFinalize(1n))
+      .to.emit(market, "FinalizationTriggered")
+      .withArgs(1n, anyRequestId());
+
+    const request = await market.getResolutionRequest(1n);
+    expect(request[0]).to.not.equal(ethers.ZeroHash);
+    expect(request[1]).to.not.equal(ethers.ZeroHash);
+    expect(request[2]).to.not.equal(ethers.ZeroHash);
+
+    const encryptedBids = await collectEncryptedBids(market, 1n);
+    const { proof, resolution } = await buildPhase3ResolutionProof(market, avs, 1n, encryptedBids, [
+      avsOperatorOne,
+      avsOperatorTwo
+    ]);
+
+    expect(resolution.winner).to.equal(bidder.address);
+    expect(resolution.winningAmount).to.equal(450n);
+
+    await expect(
+      market.connect(owner)["submitResolution(uint256,address,bytes32,uint256,bytes)"](
+        1n,
+        bidder.address,
+        winningBid,
+        450n,
+        proof
+      )
+    )
+      .to.emit(market, "ResolutionRecorded")
+      .withArgs(1n, bidder.address, winningBid);
+
+    const auction = await market.getAuction(1n);
+    expect(auction[5]).to.equal(3n);
+
+    await expect(market.getResolutionRequest(1n)).to.be.revertedWithCustomError(market, "MissingResolutionRequest");
+
+    const sellerPayout = await market.previewSellerPayout(1n);
+    const bidderRefund = await market.previewRefund(1n, bidder.address);
+    const bidderTwoRefund = await market.previewRefund(1n, bidderTwo.address);
+
+    expect(sellerPayout).to.equal(ethers.parseEther("1") + 450n);
+    expect(bidderRefund[0]).to.equal(150n);
+    expect(bidderTwoRefund[0]).to.equal(500n);
+
+    await market.connect(bidderTwo).claimRefund(1n);
+    await market.connect(bidder).claimRefund(1n);
+    await market.connect(seller).claimSellerProceeds(1n);
+    await market.connect(bidder).claimAsset(1n);
+
+    expect(await nft.ownerOf(1n)).to.equal(bidder.address);
+    expect(await ethers.provider.getBalance(await market.getAddress())).to.equal(0n);
+  });
+});
+
+function anyRequestId() {
+  return (value: string) => value !== ethers.ZeroHash;
+}

--- a/packages/contracts/test/integration/Phase1Workflow.test.ts
+++ b/packages/contracts/test/integration/Phase1Workflow.test.ts
@@ -2,6 +2,7 @@ import { loadFixture, time } from "@nomicfoundation/hardhat-network-helpers";
 import { expect } from "chai";
 
 import { deployPhase2Fixture } from "../helpers/fixtures";
+import { buildPhase3ResolutionProof, collectEncryptedBids } from "../helpers/phase3";
 
 describe("Phase 1 integration workflow", function () {
   async function deployFixture() {
@@ -9,7 +10,8 @@ describe("Phase 1 integration workflow", function () {
   }
 
   it("executes the Phase 1 scaffold from escrow to encrypted resolution", async function () {
-    const { owner, seller, bidder, adapter, market, nft, mockCofhe } = await loadFixture(deployFixture);
+    const { avs, avsOperatorOne, avsOperatorTwo, owner, seller, bidder, adapter, market, nft, mockCofhe } =
+      await loadFixture(deployFixture);
 
     await nft.connect(seller).mint(seller.address);
     await nft.connect(seller).approve(await market.getAddress(), 1n);
@@ -34,11 +36,14 @@ describe("Phase 1 integration workflow", function () {
 
     await time.increase(24 * 60 * 60 + 1);
     await market.triggerFinalize(1n);
-    await market.connect(owner)["submitResolution(uint256,address,bytes32,uint256)"](
+    const encryptedBids = await collectEncryptedBids(market, 1n);
+    const { proof } = await buildPhase3ResolutionProof(market, avs, 1n, encryptedBids, [avsOperatorOne, avsOperatorTwo]);
+    await market.connect(owner)["submitResolution(uint256,address,bytes32,uint256,bytes)"](
       1n,
       bidder.address,
       encryptedWinner,
-      450n
+      450n,
+      proof
     );
 
     const auction = await market.getAuction(1n);

--- a/packages/contracts/test/unit/AsyncResolution.test.ts
+++ b/packages/contracts/test/unit/AsyncResolution.test.ts
@@ -3,6 +3,7 @@ import { expect } from "chai";
 import { ethers } from "hardhat";
 
 import { createPhase2AuctionFixture } from "../helpers/fixtures";
+import { buildPhase3ResolutionProof, collectEncryptedBids } from "../helpers/phase3";
 
 describe("Phase 2 async resolution and settlement", function () {
   it("rejects encrypted bids that exceed the caller's escrow and stores valid bid handles", async function () {
@@ -28,7 +29,8 @@ describe("Phase 2 async resolution and settlement", function () {
   });
 
   it("settles finalized auctions through pull-based refunds, seller proceeds, and deferred NFT claims", async function () {
-    const { adapter, bidder, bidderTwo, market, nft, owner, seller } = await loadFixture(createPhase2AuctionFixture);
+    const { adapter, avs, avsOperatorOne, avsOperatorTwo, bidder, bidderTwo, market, nft, owner, seller } =
+      await loadFixture(createPhase2AuctionFixture);
 
     await market.connect(bidder).lockEscrow(1n, { value: 600n });
     await market.connect(bidderTwo).lockEscrow(1n, { value: 500n });
@@ -42,7 +44,18 @@ describe("Phase 2 async resolution and settlement", function () {
     await time.increase(24 * 60 * 60 + 1);
     await market.triggerFinalize(1n);
 
-    await expect(market.connect(owner)["submitResolution(uint256,address,bytes32,uint256)"](1n, bidder.address, winnerBid, 450n))
+    const encryptedBids = await collectEncryptedBids(market, 1n);
+    const { proof } = await buildPhase3ResolutionProof(market, avs, 1n, encryptedBids, [avsOperatorOne, avsOperatorTwo]);
+
+    await expect(
+      market.connect(owner)["submitResolution(uint256,address,bytes32,uint256,bytes)"](
+        1n,
+        bidder.address,
+        winnerBid,
+        450n,
+        proof
+      )
+    )
       .to.emit(market, "ResolutionRecorded")
       .withArgs(1n, bidder.address, winnerBid);
 
@@ -76,7 +89,8 @@ describe("Phase 2 async resolution and settlement", function () {
   });
 
   it("rejects winner resolutions that try to settle at zero", async function () {
-    const { adapter, bidder, market, owner } = await loadFixture(createPhase2AuctionFixture);
+    const { adapter, avs, avsOperatorOne, avsOperatorTwo, bidder, market, owner } =
+      await loadFixture(createPhase2AuctionFixture);
 
     await market.connect(bidder).lockEscrow(1n, { value: 600n });
     const winnerBid = await adapter.asEuint32(450);
@@ -85,9 +99,49 @@ describe("Phase 2 async resolution and settlement", function () {
     await time.increase(24 * 60 * 60 + 1);
     await market.triggerFinalize(1n);
 
+    const encryptedBids = await collectEncryptedBids(market, 1n);
+    const { proof } = await buildPhase3ResolutionProof(market, avs, 1n, encryptedBids, [avsOperatorOne, avsOperatorTwo]);
+
     await expect(
-      market.connect(owner)["submitResolution(uint256,address,bytes32,uint256)"](1n, bidder.address, winnerBid, 0n)
+      market.connect(owner)["submitResolution(uint256,address,bytes32,uint256,bytes)"](1n, bidder.address, winnerBid, 0n, proof)
     ).to.be.revertedWithCustomError(market, "ZeroWinningAmount");
+  });
+
+  it("keeps the auction in resolving and slashes attesters when the submitted resolution payload is tampered with", async function () {
+    const { adapter, avs, avsOperatorOne, avsOperatorTwo, bidder, bidderTwo, market, owner } =
+      await loadFixture(createPhase2AuctionFixture);
+
+    await market.connect(bidder).lockEscrow(1n, { value: 600n });
+    await market.connect(bidderTwo).lockEscrow(1n, { value: 500n });
+
+    await market.connect(bidder).placeBid(1n, await adapter.asEuint32(450));
+    await market.connect(bidderTwo).placeBid(1n, await adapter.asEuint32(400));
+
+    await time.increase(24 * 60 * 60 + 1);
+    await market.triggerFinalize(1n);
+
+    const encryptedBids = await collectEncryptedBids(market, 1n);
+    const { proof, request } = await buildPhase3ResolutionProof(market, avs, 1n, encryptedBids, [
+      avsOperatorOne,
+      avsOperatorTwo
+    ]);
+
+    await expect(
+      market.connect(owner)["submitResolution(uint256,address,bytes32,uint256,bytes)"](
+        1n,
+        bidder.address,
+        await adapter.asEuint32(450),
+        451n,
+        proof
+      )
+    )
+      .to.emit(market, "ResolutionRejected")
+      .withArgs(1n, request.requestId);
+
+    const auction = await market.getAuction(1n);
+    expect(auction[5]).to.equal(2n);
+    expect(await avs.slashCount(avsOperatorOne.address)).to.equal(1n);
+    expect(await avs.slashCount(avsOperatorTwo.address)).to.equal(1n);
   });
 
   it("routes seller slashing into the compensation pot and distributes refunds without loops on cancellation", async function () {

--- a/packages/contracts/test/unit/AsyncResolution.test.ts
+++ b/packages/contracts/test/unit/AsyncResolution.test.ts
@@ -144,6 +144,64 @@ describe("Phase 2 async resolution and settlement", function () {
     expect(await avs.slashCount(avsOperatorTwo.address)).to.equal(1n);
   });
 
+  it("rejects replaying a valid proof on a different market that shares the same settlement infrastructure", async function () {
+    const { adapter, avs, avsOperatorOne, avsOperatorTwo, bidder, market, nft, owner, seller, settlementEngine, slashedPot } =
+      await loadFixture(createPhase2AuctionFixture);
+
+    await market.connect(bidder).lockEscrow(1n, { value: 600n });
+    const winnerBid = await adapter.asEuint32(450);
+    await market.connect(bidder).placeBid(1n, winnerBid);
+
+    await time.increase(24 * 60 * 60 + 1);
+    await market.triggerFinalize(1n);
+
+    const encryptedBids = await collectEncryptedBids(market, 1n);
+    const { proof } = await buildPhase3ResolutionProof(market, avs, 1n, encryptedBids, [avsOperatorOne, avsOperatorTwo]);
+
+    const implementationFactory = await ethers.getContractFactory("FhenixFairMarket");
+    const implementation = await implementationFactory.deploy();
+    await implementation.waitForDeployment();
+
+    const proxyFactory = await ethers.getContractFactory("FhenixFairMarketProxy");
+    const initData = implementationFactory.interface.encodeFunctionData("initialize", [
+      await adapter.getAddress(),
+      owner.address,
+      await slashedPot.getAddress()
+    ]);
+    const proxy = await proxyFactory.deploy(await implementation.getAddress(), initData);
+    await proxy.waitForDeployment();
+
+    const secondMarket = implementationFactory.attach(await proxy.getAddress());
+    await secondMarket.connect(owner).setSettlementEngine(await settlementEngine.getAddress());
+
+    await nft.connect(seller).mint(seller.address);
+    await nft.connect(seller).approve(await secondMarket.getAddress(), 2n);
+    await secondMarket.connect(seller).createAuction(await nft.getAddress(), 2n, 24 * 60 * 60, ethers.parseEther("1"), true, {
+      value: ethers.parseEther("1")
+    });
+
+    await secondMarket.connect(bidder).lockEscrow(1n, { value: 600n });
+    await secondMarket.connect(bidder).placeBid(1n, winnerBid);
+    await time.increase(24 * 60 * 60 + 1);
+    await secondMarket.triggerFinalize(1n);
+
+    const secondRequest = await secondMarket.getResolutionRequest(1n);
+    await expect(
+      secondMarket.connect(owner)["submitResolution(uint256,address,bytes32,uint256,bytes)"](
+        1n,
+        bidder.address,
+        winnerBid,
+        450n,
+        proof
+      )
+    )
+      .to.emit(secondMarket, "ResolutionRejected")
+      .withArgs(1n, secondRequest[0]);
+
+    const secondAuction = await secondMarket.getAuction(1n);
+    expect(secondAuction[5]).to.equal(2n);
+  });
+
   it("routes seller slashing into the compensation pot and distributes refunds without loops on cancellation", async function () {
     const { adapter, bidder, bidderTwo, market, seller, slashedPot } = await loadFixture(createPhase2AuctionFixture);
 

--- a/packages/contracts/test/unit/EscrowLogic.test.ts
+++ b/packages/contracts/test/unit/EscrowLogic.test.ts
@@ -4,6 +4,7 @@ import { expect } from "chai";
 import { ethers } from "hardhat";
 
 import { createPhase2AuctionFixture, deployPhase2Fixture } from "../helpers/fixtures";
+import { buildPhase3ResolutionProof, collectEncryptedBids } from "../helpers/phase3";
 
 describe("FhenixFairMarket Phase 1", function () {
   async function deployFixture() {
@@ -18,7 +19,7 @@ describe("FhenixFairMarket Phase 1", function () {
     const { market, adapter, owner } = await loadFixture(deployFixture);
 
     await expect(market.initialize(await adapter.getAddress(), owner.address, ethers.ZeroAddress)).to.be.reverted;
-    expect(await market.contractVersion()).to.equal("phase2");
+    expect(await market.contractVersion()).to.equal("phase3");
   });
 
   it("rejects invalid initialization parameters on a fresh implementation", async function () {
@@ -167,7 +168,7 @@ describe("FhenixFairMarket Phase 1", function () {
     );
   });
 
-  it("transitions from active to resolving after the end time", async function () {
+  it("transitions from active to resolving after the end time and issues an async decryption request", async function () {
     const { market, outsider } = await loadFixture(createAuctionFixture);
 
     await time.increase(24 * 60 * 60 + 1);
@@ -178,6 +179,11 @@ describe("FhenixFairMarket Phase 1", function () {
 
     const auction = await market.getAuction(1n);
     expect(auction[5]).to.equal(2n);
+
+    const request = await market.getResolutionRequest(1n);
+    expect(request[0]).to.not.equal(ethers.ZeroHash);
+    expect(request[1]).to.not.equal(ethers.ZeroHash);
+    expect(request[2]).to.not.equal(ethers.ZeroHash);
   });
 
   it("rejects finalize calls before the auction has ended", async function () {
@@ -187,12 +193,15 @@ describe("FhenixFairMarket Phase 1", function () {
   });
 
   it("allows a no-winner resolution only when the winning amount is zero", async function () {
-    const { market, owner } = await loadFixture(createAuctionFixture);
+    const { avs, avsOperatorOne, avsOperatorTwo, market, owner } = await loadFixture(createAuctionFixture);
 
     await time.increase(24 * 60 * 60 + 1);
     await market.triggerFinalize(1n);
 
-    await expect(market.connect(owner)["submitResolution(uint256,bytes32,uint256)"](1n, ethers.ZeroHash, 0n))
+    const encryptedBids = await collectEncryptedBids(market, 1n);
+    const { proof } = await buildPhase3ResolutionProof(market, avs, 1n, encryptedBids, [avsOperatorOne, avsOperatorTwo]);
+
+    await expect(market.connect(owner)["submitResolution(uint256,bytes32,uint256,bytes)"](1n, ethers.ZeroHash, 0n, proof))
       .to.emit(market, "ResolutionRecorded")
       .withArgs(1n, ethers.ZeroAddress, ethers.ZeroHash);
 
@@ -203,13 +212,21 @@ describe("FhenixFairMarket Phase 1", function () {
   });
 
   it("rejects no-winner resolutions that try to assign a non-zero winning amount", async function () {
-    const { market, owner } = await loadFixture(createAuctionFixture);
+    const { avs, avsOperatorOne, avsOperatorTwo, market, owner } = await loadFixture(createAuctionFixture);
 
     await time.increase(24 * 60 * 60 + 1);
     await market.triggerFinalize(1n);
 
+    const encryptedBids = await collectEncryptedBids(market, 1n);
+    const { proof } = await buildPhase3ResolutionProof(market, avs, 1n, encryptedBids, [avsOperatorOne, avsOperatorTwo]);
+
     await expect(
-      market.connect(owner)["submitResolution(uint256,bytes32,uint256)"](1n, ethers.encodeBytes32String("winner"), 77n)
+      market.connect(owner)["submitResolution(uint256,bytes32,uint256,bytes)"](
+        1n,
+        ethers.encodeBytes32String("winner"),
+        77n,
+        proof
+      )
     ).to.be.revertedWithCustomError(market, "WinnerRequiredForWinningAmount");
   });
 
@@ -217,7 +234,12 @@ describe("FhenixFairMarket Phase 1", function () {
     const { market, owner } = await loadFixture(createAuctionFixture);
 
     await expect(
-      market.connect(owner)["submitResolution(uint256,bytes32,uint256)"](1n, ethers.encodeBytes32String("winner"), 10n)
+      market.connect(owner)["submitResolution(uint256,bytes32,uint256,bytes)"](
+        1n,
+        ethers.encodeBytes32String("winner"),
+        10n,
+        "0x"
+      )
     ).to.be.revertedWithCustomError(market, "UnexpectedAuctionState");
   });
 

--- a/packages/contracts/test/unit/SettlementComponents.test.ts
+++ b/packages/contracts/test/unit/SettlementComponents.test.ts
@@ -37,7 +37,7 @@ describe("Phase 2 settlement components", function () {
   }
 
   it("covers the timeout, slash, payout, and pro-rata math branches in SettlementEngine", async function () {
-    const { avs, settlementEngine } = await loadFixture(deployFixture);
+    const { avs, recipient, settlementEngine } = await loadFixture(deployFixture);
 
     expect(await settlementEngine.computeDynamicTimeout(0n)).to.equal(15n * 60n);
     expect(await settlementEngine.computeDynamicTimeout(1n)).to.equal(15n * 60n);
@@ -62,7 +62,7 @@ describe("Phase 2 settlement components", function () {
     expect(await settlementEngine.computeProRataShare(10n, 100n, 0n)).to.equal(0n);
     expect(await settlementEngine.computeProRataShare(25n, 100n, 80n)).to.equal(20n);
 
-    const request = await settlementEngine.prepareResolutionRequest(1n, 2, 100n);
+    const request = await settlementEngine.prepareResolutionRequest(recipient.address, 1n, 2, 100n);
     expect(request.requestId).to.not.equal(ethers.ZeroHash);
     expect(request.winnerHandle).to.not.equal(ethers.ZeroHash);
     expect(request.amountHandle).to.not.equal(ethers.ZeroHash);
@@ -83,7 +83,7 @@ describe("Phase 2 settlement components", function () {
       "ZeroAddress"
     );
     await expect(
-      settlementEngine.verifyResolutionProof(1n, ethers.ZeroHash, ethers.ZeroAddress, ethers.ZeroHash, 0n, "0x")
+      settlementEngine.verifyResolutionProof(ethers.ZeroAddress, 1n, ethers.ZeroHash, ethers.ZeroAddress, ethers.ZeroHash, 0n, "0x")
     ).to.be.revertedWithCustomError(settlementEngine, "ZeroAddress");
 
     const avsFactory = await ethers.getContractFactory("MockEigenLayerAVS");
@@ -100,7 +100,7 @@ describe("Phase 2 settlement components", function () {
   it("slashes duplicate operators only once when an attestation envelope is malformed", async function () {
     const { avs, operatorOne, recipient } = await loadFixture(deployFixture);
 
-    const digest = await avs.computeDigest(1n, ethers.id("request"), recipient.address, ethers.ZeroHash, 1n);
+    const digest = await avs.computeDigest(recipient.address, 1n, ethers.id("request"), recipient.address, ethers.ZeroHash, 1n);
     const signature = await operatorOne.signMessage(ethers.getBytes(digest));
     const malformedProof = ethers.AbiCoder.defaultAbiCoder().encode(
       [
@@ -110,11 +110,36 @@ describe("Phase 2 settlement components", function () {
     );
 
     expect(
-      await avs.verifyAttestation.staticCall(1n, ethers.id("request"), recipient.address, ethers.ZeroHash, 1n, malformedProof)
+      await avs.verifyAttestation.staticCall(
+        recipient.address,
+        1n,
+        ethers.id("request"),
+        recipient.address,
+        ethers.ZeroHash,
+        1n,
+        malformedProof
+      )
     ).to.equal(false);
 
-    await avs.verifyAttestation(1n, ethers.id("request"), recipient.address, ethers.ZeroHash, 1n, malformedProof);
+    await avs.verifyAttestation(recipient.address, 1n, ethers.id("request"), recipient.address, ethers.ZeroHash, 1n, malformedProof);
     expect(await avs.slashCount(operatorOne.address)).to.equal(1n);
+  });
+
+  it("domain-separates request ids and AVS digests by market address", async function () {
+    const { avs, operatorOne, recipient, settlementEngine } = await loadFixture(deployFixture);
+
+    const marketOne = recipient.address;
+    const marketTwo = operatorOne.address;
+    const requestOne = await settlementEngine.prepareResolutionRequest(marketOne, 7n, 2, 100n);
+    const requestTwo = await settlementEngine.prepareResolutionRequest(marketTwo, 7n, 2, 100n);
+
+    expect(requestOne.requestId).to.not.equal(requestTwo.requestId);
+    expect(requestOne.winnerHandle).to.not.equal(requestTwo.winnerHandle);
+    expect(requestOne.amountHandle).to.not.equal(requestTwo.amountHandle);
+
+    const digestOne = await avs.computeDigest(marketOne, 7n, requestOne.requestId, recipient.address, ethers.ZeroHash, 1n);
+    const digestTwo = await avs.computeDigest(marketTwo, 7n, requestOne.requestId, recipient.address, ethers.ZeroHash, 1n);
+    expect(digestOne).to.not.equal(digestTwo);
   });
 
   it("guards SlashedPot setup, access control, and successful pull-based compensation claims", async function () {

--- a/packages/contracts/test/unit/SettlementComponents.test.ts
+++ b/packages/contracts/test/unit/SettlementComponents.test.ts
@@ -4,15 +4,19 @@ import { ethers } from "hardhat";
 
 describe("Phase 2 settlement components", function () {
   async function deployFixture() {
-    const [owner, outsider, recipient] = await ethers.getSigners();
+    const [owner, outsider, recipient, operatorOne, operatorTwo, operatorThree] = await ethers.getSigners();
 
     const settlementEngineFactory = await ethers.getContractFactory("SettlementEngine");
-    const settlementEngine = await settlementEngineFactory.deploy();
+    const settlementEngine = await settlementEngineFactory.deploy(owner.address);
     await settlementEngine.waitForDeployment();
 
     const slashedPotFactory = await ethers.getContractFactory("SlashedPot");
     const slashedPot = await slashedPotFactory.deploy(owner.address, await settlementEngine.getAddress());
     await slashedPot.waitForDeployment();
+
+    const avsFactory = await ethers.getContractFactory("MockEigenLayerAVS");
+    const avs = await avsFactory.deploy(owner.address, [operatorOne.address, operatorTwo.address, operatorThree.address], 2);
+    await avs.waitForDeployment();
 
     const rejectingReceiverFactory = await ethers.getContractFactory("MockRejectingReceiver");
     const rejectingReceiver = await rejectingReceiverFactory.deploy();
@@ -22,6 +26,10 @@ describe("Phase 2 settlement components", function () {
       owner,
       outsider,
       recipient,
+      operatorOne,
+      operatorTwo,
+      operatorThree,
+      avs,
       settlementEngine,
       slashedPot,
       rejectingReceiver
@@ -29,7 +37,7 @@ describe("Phase 2 settlement components", function () {
   }
 
   it("covers the timeout, slash, payout, and pro-rata math branches in SettlementEngine", async function () {
-    const { settlementEngine } = await loadFixture(deployFixture);
+    const { avs, settlementEngine } = await loadFixture(deployFixture);
 
     expect(await settlementEngine.computeDynamicTimeout(0n)).to.equal(15n * 60n);
     expect(await settlementEngine.computeDynamicTimeout(1n)).to.equal(15n * 60n);
@@ -53,6 +61,60 @@ describe("Phase 2 settlement components", function () {
     expect(await settlementEngine.computeProRataShare(10n, 0n, 50n)).to.equal(0n);
     expect(await settlementEngine.computeProRataShare(10n, 100n, 0n)).to.equal(0n);
     expect(await settlementEngine.computeProRataShare(25n, 100n, 80n)).to.equal(20n);
+
+    const request = await settlementEngine.prepareResolutionRequest(1n, 2, 100n);
+    expect(request.requestId).to.not.equal(ethers.ZeroHash);
+    expect(request.winnerHandle).to.not.equal(ethers.ZeroHash);
+    expect(request.amountHandle).to.not.equal(ethers.ZeroHash);
+
+    await settlementEngine.setAVS(await avs.getAddress());
+    expect(await settlementEngine.avs()).to.equal(await avs.getAddress());
+  });
+
+  it("guards AVS configuration and rejects invalid verifier setups", async function () {
+    const { owner } = await loadFixture(deployFixture);
+
+    const settlementEngineFactory = await ethers.getContractFactory("SettlementEngine");
+    const settlementEngine = await settlementEngineFactory.deploy(owner.address);
+    await settlementEngine.waitForDeployment();
+
+    await expect(settlementEngine.setAVS(ethers.ZeroAddress)).to.be.revertedWithCustomError(
+      settlementEngine,
+      "ZeroAddress"
+    );
+    await expect(
+      settlementEngine.verifyResolutionProof(1n, ethers.ZeroHash, ethers.ZeroAddress, ethers.ZeroHash, 0n, "0x")
+    ).to.be.revertedWithCustomError(settlementEngine, "ZeroAddress");
+
+    const avsFactory = await ethers.getContractFactory("MockEigenLayerAVS");
+    await expect(avsFactory.deploy(owner.address, [owner.address], 0)).to.be.revertedWithCustomError(
+      avsFactory,
+      "InvalidThreshold"
+    );
+    await expect(avsFactory.deploy(owner.address, [owner.address, owner.address], 1)).to.be.revertedWithCustomError(
+      avsFactory,
+      "DuplicateOperator"
+    );
+  });
+
+  it("slashes duplicate operators only once when an attestation envelope is malformed", async function () {
+    const { avs, operatorOne, recipient } = await loadFixture(deployFixture);
+
+    const digest = await avs.computeDigest(1n, ethers.id("request"), recipient.address, ethers.ZeroHash, 1n);
+    const signature = await operatorOne.signMessage(ethers.getBytes(digest));
+    const malformedProof = ethers.AbiCoder.defaultAbiCoder().encode(
+      [
+        "tuple(uint256 auctionId, bytes32 requestId, address winner, bytes32 winnerCiphertext, uint256 winningAmount, address[] operators, bytes[] signatures)"
+      ],
+      [[1n, ethers.id("request"), recipient.address, ethers.ZeroHash, 1n, [operatorOne.address, operatorOne.address], [signature, signature]]]
+    );
+
+    expect(
+      await avs.verifyAttestation.staticCall(1n, ethers.id("request"), recipient.address, ethers.ZeroHash, 1n, malformedProof)
+    ).to.equal(false);
+
+    await avs.verifyAttestation(1n, ethers.id("request"), recipient.address, ethers.ZeroHash, 1n, malformedProof);
+    expect(await avs.slashCount(operatorOne.address)).to.equal(1n);
   });
 
   it("guards SlashedPot setup, access control, and successful pull-based compensation claims", async function () {

--- a/packages/keeper/config.ts
+++ b/packages/keeper/config.ts
@@ -1,0 +1,22 @@
+export interface KeeperConfig {
+  pollIntervalMs: number;
+  finalizationDriftSeconds: number;
+  requestTimeoutMs: number;
+  maxRetries: number;
+  queueCapacity: number;
+}
+
+export const defaultKeeperConfig: KeeperConfig = {
+  pollIntervalMs: 12_000,
+  finalizationDriftSeconds: 12,
+  requestTimeoutMs: 90_000,
+  maxRetries: 3,
+  queueCapacity: 256
+};
+
+export function createKeeperConfig(overrides: Partial<KeeperConfig> = {}): KeeperConfig {
+  return {
+    ...defaultKeeperConfig,
+    ...overrides
+  };
+}

--- a/packages/keeper/package.json
+++ b/packages/keeper/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "keeper",
+  "private": true,
+  "version": "0.1.0",
+  "engines": {
+    "node": ">=22 <23"
+  }
+}

--- a/packages/keeper/services/auctionMonitor.ts
+++ b/packages/keeper/services/auctionMonitor.ts
@@ -1,0 +1,60 @@
+import { createKeeperConfig, type KeeperConfig } from "../config";
+
+export interface AuctionSnapshot {
+  auctionId: bigint;
+  state: bigint;
+  endTime: bigint;
+}
+
+export interface ResolutionRequestSnapshot {
+  requestId: string;
+  winnerHandle: string;
+  amountHandle: string;
+  requestedAt: bigint;
+}
+
+export interface MarketMonitorReader {
+  getAuction(auctionId: bigint): Promise<readonly unknown[]>;
+  getResolutionRequest(auctionId: bigint): Promise<readonly [string, string, string, bigint]>;
+}
+
+export interface PendingResolutionJob {
+  auctionId: bigint;
+  requestId: string;
+  winnerHandle: string;
+  amountHandle: string;
+  requestedAt: bigint;
+}
+
+export class AuctionMonitor {
+  constructor(
+    private readonly reader: MarketMonitorReader,
+    private readonly config: KeeperConfig = createKeeperConfig()
+  ) {}
+
+  async scanExpiredAuctions(auctionIds: readonly bigint[], now: bigint): Promise<bigint[]> {
+    const ready: bigint[] = [];
+
+    for (const auctionId of auctionIds) {
+      const auction = await this.reader.getAuction(auctionId);
+      const state = BigInt(auction[5] as bigint);
+      const endTime = BigInt(auction[3] as bigint);
+      if (state === 1n && now + BigInt(this.config.finalizationDriftSeconds) >= endTime) {
+        ready.push(auctionId);
+      }
+    }
+
+    return ready;
+  }
+
+  async inspectTriggeredAuction(auctionId: bigint): Promise<PendingResolutionJob> {
+    const request = await this.reader.getResolutionRequest(auctionId);
+    return {
+      auctionId,
+      requestId: request[0],
+      winnerHandle: request[1],
+      amountHandle: request[2],
+      requestedAt: BigInt(request[3])
+    };
+  }
+}

--- a/packages/keeper/services/avsSubmitter.ts
+++ b/packages/keeper/services/avsSubmitter.ts
@@ -1,0 +1,40 @@
+export interface AttestationPayload {
+  auctionId: bigint;
+  requestId: string;
+  winner: string;
+  winnerCiphertext: string;
+  winningAmount: bigint;
+}
+
+export interface AVSOperatorSigner {
+  address: string;
+  signDigest(digest: string): Promise<string>;
+}
+
+export interface AttestationProofEnvelope extends AttestationPayload {
+  operators: string[];
+  signatures: string[];
+}
+
+export class AvsSubmitter {
+  constructor(private readonly threshold: number) {}
+
+  async collectProof(
+    payload: AttestationPayload,
+    digest: string,
+    operators: readonly AVSOperatorSigner[]
+  ): Promise<AttestationProofEnvelope> {
+    if (operators.length < this.threshold) {
+      throw new Error(`Threshold not met: expected ${this.threshold}, received ${operators.length}`);
+    }
+
+    const selectedOperators = operators.slice(0, this.threshold);
+    const signatures = await Promise.all(selectedOperators.map((operator) => operator.signDigest(digest)));
+
+    return {
+      ...payload,
+      operators: selectedOperators.map((operator) => operator.address),
+      signatures
+    };
+  }
+}

--- a/packages/keeper/services/cofheDispatcher.ts
+++ b/packages/keeper/services/cofheDispatcher.ts
@@ -1,0 +1,98 @@
+export interface EncryptedBidRecord {
+  bidder: string;
+  encryptedBid: string;
+  availableEscrow: bigint;
+}
+
+export interface CoFheDispatchJob {
+  auctionId: bigint;
+  requestId: string;
+  winnerHandle: string;
+  amountHandle: string;
+  bids: readonly EncryptedBidRecord[];
+}
+
+export interface CoFheResolution {
+  requestId: string;
+  winnerHandle: string;
+  amountHandle: string;
+  winner: string | null;
+  winnerCiphertext: string;
+  winningAmount: bigint;
+  latencyMs: number;
+}
+
+export interface DispatchQueue {
+  enqueue(job: CoFheDispatchJob): Promise<void>;
+  markCompleted(requestId: string, resolution: CoFheResolution): Promise<void>;
+}
+
+export class InMemoryDispatchQueue implements DispatchQueue {
+  readonly pending = new Map<string, CoFheDispatchJob>();
+  readonly completed = new Map<string, CoFheResolution>();
+
+  async enqueue(job: CoFheDispatchJob): Promise<void> {
+    this.pending.set(job.requestId, job);
+  }
+
+  async markCompleted(requestId: string, resolution: CoFheResolution): Promise<void> {
+    this.pending.delete(requestId);
+    this.completed.set(requestId, resolution);
+  }
+}
+
+export class CofheDispatcher {
+  constructor(
+    private readonly queue: DispatchQueue = new InMemoryDispatchQueue(),
+    private readonly now: () => number = () => Date.now()
+  ) {}
+
+  async dispatch(job: CoFheDispatchJob): Promise<CoFheResolution> {
+    const startedAt = this.now();
+    await this.queue.enqueue(job);
+
+    const winner = pickHighestEncryptedBid(job.bids);
+    const resolution: CoFheResolution = {
+      requestId: job.requestId,
+      winnerHandle: job.winnerHandle,
+      amountHandle: job.amountHandle,
+      winner: winner?.bidder ?? null,
+      winnerCiphertext: winner?.encryptedBid ?? ZERO_HASH,
+      winningAmount: winner ? decodeEncryptedUint32(winner.encryptedBid) : 0n,
+      latencyMs: this.now() - startedAt
+    };
+
+    await this.queue.markCompleted(job.requestId, resolution);
+    return resolution;
+  }
+}
+
+export const ZERO_HASH = `0x${"0".repeat(64)}`;
+
+export function decodeEncryptedUint32(ciphertext: string): bigint {
+  const parsed = BigInt(ciphertext);
+  const kind = parsed >> 248n;
+  if (kind !== 1n) {
+    throw new Error(`Unsupported ciphertext kind: ${kind.toString()}`);
+  }
+
+  return parsed & ((1n << 248n) - 1n);
+}
+
+export function pickHighestEncryptedBid(bids: readonly EncryptedBidRecord[]): EncryptedBidRecord | null {
+  let winner: EncryptedBidRecord | null = null;
+  let highestBid = -1n;
+
+  for (const bid of bids) {
+    const amount = decodeEncryptedUint32(bid.encryptedBid);
+    if (amount > bid.availableEscrow) {
+      continue;
+    }
+    if (winner === null || amount > highestBid) {
+      winner = bid;
+      highestBid = amount;
+    }
+  }
+
+  return winner;
+}

--- a/packages/keeper/tsconfig.json
+++ b/packages/keeper/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist"
+  },
+  "include": ["./**/*.ts"]
+}


### PR DESCRIPTION
## Summary

This PR implements the Phase 3 async settlement architecture for FairMarket.

- adds asynchronous finalization requests with `FinalizationTriggered` and `DecryptionRequested`
- tracks bidder orderbooks on-chain without storing plaintext bid submissions in events
- verifies settlement submissions through a mock EigenLayer AVS threshold-attestation flow
- introduces a `packages/keeper` workspace with monitor, CoFHE dispatcher, and AVS submitter services
- adds an end-to-end CoFHE integration test plus AVS tamper-rejection coverage

## Why

Phase 2 still relied on direct owner-driven resolution submission. Phase 3 moves the protocol into the intended async model:

- contract finalization becomes a request to external settlement infrastructure
- keepers can reconstruct the encrypted orderbook and produce a candidate result
- AVS proofs are checked before a resolution can finalize the auction
- malformed or tampered proof envelopes do not finalize the auction and trigger symbolic slashing in the mock AVS

## Impact

- `FhenixFairMarket.sol` now tracks pending resolution requests and bidder lists
- `SettlementEngine.sol` now derives request handles and delegates AVS proof verification
- `MockEigenLayerAVS.sol` simulates threshold-attested verification with operator slashing
- regression tests from earlier phases were updated to use AVS-backed `submitResolution(...)`
- new docs in `docs/phase-3-cofhe-avs.md` describe the Phase 3 flow end to end

## Validation

- `pnpm --filter contracts compile`
- `pnpm --filter contracts test`
- `pnpm --filter contracts coverage`
- coverage result: `91.13%` statements, `67.47%` branch, `96.63%` functions, `87.14%` lines

Closes #21
Closes #22
Closes #23
Closes #24
Refs #3
