### PR TITLE
fix(security): freeze prototype risk posture

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Fhenix-FairMarket
 
-> **Sealed-Bid Auction Protocol** — Privacy-preserving, gas-efficient, and censorship-resistant, powered by CoFHE Coprocessing and EigenLayer AVS.
+> **Sealed-Bid Auction Prototype** — currently under security remediation; not yet production-private.
 
 <div align="center">
 
@@ -8,7 +8,7 @@
 [![Solidity](https://img.shields.io/badge/Solidity-^0.8.25-363636?logo=solidity)](https://soliditylang.org)
 [![Fhenix](https://img.shields.io/badge/Fhenix-fhEVM-6C3CE1)](https://fhenix.io)
 [![EigenLayer](https://img.shields.io/badge/EigenLayer-AVS-0ea5e9)](https://eigenlayer.xyz)
-[![Status](https://img.shields.io/badge/Status-Sepolia%20Live-22c55e)](https://fhenix-fair-market-app.vercel.app/portfolio)
+[![Status](https://img.shields.io/badge/Status-Security%20Review-d97706)](./SECURITY_STATUS.md)
 [![Network](https://img.shields.io/badge/Network-Ethereum%20Sepolia-2563eb)](https://sepolia.etherscan.io)
 [![Version](https://img.shields.io/badge/Version-2.0-orange)]()
 
@@ -18,15 +18,22 @@
 
 [![Landing Page](https://img.shields.io/badge/Landing%20Page-Open-7c3aed?style=for-the-badge)](https://fhenix-fair-market-lp.vercel.app/)
 [![Documentation](https://img.shields.io/badge/Documentation-Read-0ea5e9?style=for-the-badge)](https://doc-fhenix-fair-market.vercel.app/)
-[![Live App](https://img.shields.io/badge/Live%20App-Sepolia-22c55e?style=for-the-badge)](https://fhenix-fair-market-app.vercel.app/portfolio)
+[![Prototype App](https://img.shields.io/badge/Prototype%20App-Sepolia-d97706?style=for-the-badge)](https://fhenix-fair-market-app.vercel.app/portfolio)
 
 </div>
+
+## Security Warning
+
+- The current repository is in **security remediation**.
+- The shipped `CofheAdapter` path is a **prototype** and does **not** provide production-grade bid privacy.
+- Public or testnet deployments should be treated as **review/demo-only** until the remediation work is complete.
+- See [SECURITY_STATUS.md](./SECURITY_STATUS.md) for the current posture.
 
 ## Public Entry Points
 
 - **Landing Page:** project overview and public-facing introduction
 - **Documentation:** technical and user documentation
-- **Live App:** deployed application connected to Ethereum Sepolia
+- **Prototype App:** deployed review build connected to Ethereum Sepolia
 
 > Public links:
 > Landing - `https://fhenix-fair-market-lp.vercel.app/`
@@ -67,9 +74,9 @@
 
 ## 🔷 Overview
 
-**Fhenix-FairMarket** is a decentralized sealed-bid auction protocol that resolves the fundamental tension between **absolute privacy** and **economic viability** in on-chain auctions.
+**Fhenix-FairMarket** is a decentralized sealed-bid auction prototype exploring the tension between privacy goals and economic viability in on-chain auctions.
 
-Instead of executing expensive Fully Homomorphic Encryption (FHE) operations on-chain, the protocol adopts an **Asynchronous FHE Coprocessing** model via the `CoFHE` architecture, backed by `EigenLayer AVS` for economic verification — reducing gas costs by **~99.9%** while preserving mathematical integrity and eliminating any trusted intermediary.
+Instead of executing expensive Fully Homomorphic Encryption (FHE) operations on-chain, the protocol adopts an **Asynchronous FHE Coprocessing** model via the `CoFHE` architecture, backed by `EigenLayer AVS` for economic verification. The current repository still contains prototype privacy plumbing and should not be described as production-private until the remediation issues are closed.
 
 ### Key Innovations
 

--- a/SECURITY_STATUS.md
+++ b/SECURITY_STATUS.md
@@ -1,0 +1,37 @@
+# Security Status
+
+## Current Posture
+
+`Fhenix-FairMarket` is currently in a **security remediation** state and should be treated as a **prototype** rather than a production-ready privacy protocol.
+
+## What Is Not Production-Ready Yet
+
+- The current `CofheAdapter` path uses placeholder reversible encoding and does **not** provide production-grade bid confidentiality.
+- Legacy witness claim paths were unsafe because they exposed reclaim material in calldata.
+- Additional fixes are still required around shielded bid coverage, fallback accounting, and settlement liveness.
+
+## Deployment Guidance
+
+- Do **not** deploy the current prototype adapter stack to public networks.
+- Use local development networks only until the production opaque-ciphertext path is implemented.
+- Treat any public or testnet deployment as review/demo-only unless the remediation issues are closed.
+
+## User-Facing Claim
+
+Until the privacy remediation is complete, the application should be described as:
+
+- `sealed-bid prototype`
+- `review build`
+- `security remediation build`
+
+and **not** as:
+
+- `production-private`
+- `confidential by default`
+- `privacy-preserving in production`
+
+## Source of Truth
+
+- [security_audit_report.md](./security_audit_report.md)
+- [security_remediation_plan.md](./security_remediation_plan.md)
+- [github_issues_master_draft.md](./github_issues_master_draft.md)

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -1,5 +1,12 @@
 # Security Model
 
+## Current Prototype Limitations
+
+- The current `CofheAdapter` path is a prototype and does not provide production-grade ciphertext privacy.
+- Public-network deployments must not rely on the current adapter as proof of private bidding.
+- Legacy witness claim paths are being retired in favor of authorization-based claims because calldata-visible secrets are unsafe.
+- Shielded bid coverage and fallback accounting still require the follow-up remediation items tracked in the security plan.
+
 ## Trust Boundaries
 
 - **Market contract**
@@ -24,6 +31,8 @@
 
 ## Key Failure Modes
 
+- **Prototype bid privacy misunderstood as production privacy**
+  - Mitigation: explicit repository warning, `SECURITY_STATUS.md`, frontend review language, and deployment guards for the current adapter path.
 - **Keeper outage**
   - Mitigation: backfill from chain state, metrics freshness alerts, distributed finalize lock.
 - **CoFHE delay**
@@ -32,6 +41,12 @@
   - Mitigation: digest verification and symbolic slashing log entries.
 - **User misconfiguration**
   - Mitigation: Sepolia-only app guard, explicit contract registry readiness, generated runtime env snippets.
+
+## Current Operator Guidance
+
+- Treat the current stack as review/demo-only on public testnets.
+- Do not market the current bid lane as mathematically private until the real opaque-ciphertext path lands.
+- Prefer local development networks for adapter and settlement rehearsals while remediation remains open.
 
 ## Audit Focus
 

--- a/packages/contracts/README.md
+++ b/packages/contracts/README.md
@@ -6,7 +6,7 @@ This workspace contains the runnable Phase 1 and Phase 2 contract foundation for
 
 - `contracts/core/FhenixFairMarket.sol`: upgradeable auction core with escrow locking, encrypted bid placement, guarded state transitions, refunds, seller settlement, and fallback logic
 - `contracts/core/FhenixFairMarketProxy.sol`: thin `ERC1967Proxy` wrapper for UUPS deployments
-- `contracts/adapters/CofheAdapter.sol`: adapter boundary that keeps the core contract isolated from future CoFHE vendor changes
+- `contracts/adapters/CofheAdapter.sol`: local-development prototype adapter boundary; the current reversible placeholder encoding is not production-private
 - `contracts/adapters/NFTGuard.sol`: escrow helper for NFT custody and terminal asset release
 - `contracts/privacy/ShieldedEscrowVault.sol`: Privacy Phase 1 vault for commitment-based escrow deposits and shielded refund claims
 - `contracts/privacy/ShieldedIdentityRegistry.sol`: Privacy Phase 3 alias layer that separates settlement identity from raw escrow-note commitment
@@ -41,6 +41,7 @@ pnpm coverage
 ## Notes
 
 - The issue text references an older package name for the CoFHE Hardhat plugin. The maintained package integrated here is `cofhe-hardhat-plugin`.
+- Security status: this workspace is under remediation. The current `CofheAdapter` is local-development only and deployment scripts intentionally block the prototype adapter on public networks.
 - The CoFHE Hardhat plugin is installed and version-pinned in the workspace so later Fhenix-network phases can activate it without reworking dependencies.
 - The default Phase 1 test path stays on the deterministic local adapter/mock implementation to keep the architectural foundation stable while full network-backed CoFHE flows are deferred to later phases.
 - The adapter now models typed ciphertext handles (`euint32`, `ebool`), comparison helpers (`lte`, `gt`), conditional selection, and encrypted bid-coverage checks.

--- a/packages/contracts/contracts/adapters/CofheAdapter.sol
+++ b/packages/contracts/contracts/adapters/CofheAdapter.sol
@@ -4,6 +4,9 @@ pragma solidity ^0.8.25;
 import "../interfaces/ICofheAdapter.sol";
 import "../utils/CofheCiphertextEncoding.sol";
 
+/// @notice Local-development prototype adapter only.
+/// @dev This adapter uses reversible placeholder encoding and MUST NOT be used
+///      as a production privacy boundary on public networks.
 contract CofheAdapter is ICofheAdapter {
     using CofheCiphertextEncoding for bytes32;
 

--- a/packages/contracts/deploy/00_deploy_adapters.ts
+++ b/packages/contracts/deploy/00_deploy_adapters.ts
@@ -1,10 +1,18 @@
 import { ethers, network } from "hardhat";
 
-import { ensureDirectory, readDeploymentFile, resolveDeploymentPaths, resolveNetworkDescriptor, writeJsonFile } from "./utils";
+import {
+  assertPrototypeAdapterLocalOnly,
+  ensureDirectory,
+  readDeploymentFile,
+  resolveDeploymentPaths,
+  resolveNetworkDescriptor,
+  writeJsonFile
+} from "./utils";
 
 async function main() {
   const { deploymentDirectory, deploymentFile } = resolveDeploymentPaths(network.name);
   const descriptor = await resolveNetworkDescriptor(network.name);
+  assertPrototypeAdapterLocalOnly(descriptor);
   await ensureDirectory(deploymentDirectory);
   const [defaultSigner] = await ethers.getSigners();
   const initialOwner = process.env.PHASE1_INITIAL_OWNER || defaultSigner.address;

--- a/packages/contracts/deploy/01_deploy_core_proxy.ts
+++ b/packages/contracts/deploy/01_deploy_core_proxy.ts
@@ -1,10 +1,17 @@
 import { ethers, network } from "hardhat";
 
-import { readDeploymentFile, resolveDeploymentPaths, resolveNetworkDescriptor, writeJsonFile } from "./utils";
+import {
+  assertPrototypeAdapterLocalOnly,
+  readDeploymentFile,
+  resolveDeploymentPaths,
+  resolveNetworkDescriptor,
+  writeJsonFile
+} from "./utils";
 
 async function main() {
   const { deploymentFile } = resolveDeploymentPaths(network.name);
   const descriptor = await resolveNetworkDescriptor(network.name);
+  assertPrototypeAdapterLocalOnly(descriptor);
 
   const existing = await readDeploymentFile(deploymentFile);
   let adapterAddress = process.env.PHASE1_ADAPTER_ADDRESS || existing.adapter;

--- a/packages/contracts/deploy/06_deploy_cofhe_adapter.ts
+++ b/packages/contracts/deploy/06_deploy_cofhe_adapter.ts
@@ -1,9 +1,16 @@
 import { ethers, network } from "hardhat";
 
-import { readDeploymentFile, resolveDeploymentPaths, resolveNetworkDescriptor, writeJsonFile } from "./utils";
+import {
+  assertPrototypeAdapterLocalOnly,
+  readDeploymentFile,
+  resolveDeploymentPaths,
+  resolveNetworkDescriptor,
+  writeJsonFile
+} from "./utils";
 
 async function main() {
   const descriptor = await resolveNetworkDescriptor(network.name);
+  assertPrototypeAdapterLocalOnly(descriptor);
   const { deploymentFile } = resolveDeploymentPaths(network.name);
   const existing = await readDeploymentFile(deploymentFile);
   const [defaultSigner] = await ethers.getSigners();

--- a/packages/contracts/deploy/utils.ts
+++ b/packages/contracts/deploy/utils.ts
@@ -21,6 +21,9 @@ export interface NetworkDescriptor {
   blockExplorerUrl: string;
 }
 
+const LOCAL_NETWORK_NAMES = new Set(["hardhat", "localhost", "anvil"]);
+const LOCAL_CHAIN_IDS = new Set([1337, 31337]);
+
 export function resolveDeploymentPaths(targetNetwork: string = network.name): DeploymentPaths {
   const deploymentDirectory = path.join(__dirname, "..", "deployments");
   return {
@@ -66,6 +69,21 @@ export async function resolveNetworkDescriptor(targetNetwork: string = network.n
     websocketUrl: resolveWebsocketUrl(targetNetwork),
     blockExplorerUrl: resolveBlockExplorerUrl(targetNetwork, numericChainId)
   };
+}
+
+export function assertPrototypeAdapterLocalOnly(descriptor: NetworkDescriptor): void {
+  const isLocalNetwork = LOCAL_NETWORK_NAMES.has(descriptor.name) || LOCAL_CHAIN_IDS.has(descriptor.chainId);
+  if (isLocalNetwork) {
+    return;
+  }
+
+  throw new Error(
+    [
+      `Prototype CofheAdapter deployment is disabled on non-local networks (${descriptor.name}, chainId=${descriptor.chainId}).`,
+      "The current adapter path is reversible placeholder encoding and must not be deployed to public networks.",
+      "Use a production opaque-ciphertext adapter before deploying this stack outside local development."
+    ].join(" ")
+  );
 }
 
 export function resolveRpcUrl(targetNetwork: string): string {

--- a/packages/frontend/src/app/about/page.tsx
+++ b/packages/frontend/src/app/about/page.tsx
@@ -47,7 +47,7 @@ const trustLinks = [
     label: "Compatibility",
     title: "Check the coprocessor reference",
     href: appConfig.coprocessor.referenceUrl,
-    body: "The Fhenix compatibility reference explains the CoFHE context surrounding the confidential settlement path."
+    body: "The Fhenix compatibility reference explains the CoFHE context surrounding the prototype settlement path."
   }
 ] as const;
 
@@ -57,7 +57,7 @@ export default function AboutPage() {
       <section className="about-hero">
         <div className="about-hero__copy">
           <p className="eyebrow">About</p>
-          <h1 className="section-title">Confidential auctions, explained without the noise.</h1>
+          <h1 className="section-title">Sealed-bid prototypes, explained without the noise.</h1>
           <p className="section-note about-hero__note">
             Fhenix-FairMarket is a privacy-first auction desk designed to feel calm, legible, and trustworthy even
             when the underlying protocol path is complex.
@@ -174,7 +174,7 @@ export default function AboutPage() {
 
           <details className="about-accordion">
             <summary>
-              <span>Confidential settlement context</span>
+              <span>Prototype settlement context</span>
               <span className="signal-label">Reference</span>
             </summary>
             <div className="about-accordion__body">

--- a/packages/frontend/src/app/globals.css
+++ b/packages/frontend/src/app/globals.css
@@ -927,7 +927,6 @@ select:focus-visible {
   -webkit-box-orient: vertical;
   overflow: hidden;
 }
-.auction-card__confidentiality,
 .auction-card__summary,
 .timeline-row__value,
 .detail-card__copy,
@@ -935,14 +934,6 @@ select:focus-visible {
   margin: 0;
   color: var(--text-mid);
   line-height: 1.65;
-}
-.auction-card__confidentiality {
-  color: var(--text-mid);
-  font-size: 0.84rem;
-  display: -webkit-box;
-  -webkit-line-clamp: 2;
-  -webkit-box-orient: vertical;
-  overflow: hidden;
 }
 .auction-card__metrics,
 .summary-signal-grid,

--- a/packages/frontend/src/app/layout.tsx
+++ b/packages/frontend/src/app/layout.tsx
@@ -25,7 +25,7 @@ const dataMono = JetBrains_Mono({
 
 export const metadata: Metadata = {
   title: "Fhenix-FairMarket App",
-  description: "Confidential sealed-bid auctions with a premium Sepolia-first experience."
+  description: "Sealed-bid auction prototype with a premium Sepolia-first experience."
 };
 
 export const viewport: Viewport = {

--- a/packages/frontend/src/app/marketplace/[auctionId]/page.tsx
+++ b/packages/frontend/src/app/marketplace/[auctionId]/page.tsx
@@ -76,7 +76,7 @@ export default async function AuctionDetailsPage({ params }: AuctionDetailsPageP
             </article>
             <article className="detail-hero__summary-card">
               <span>Privacy</span>
-              <strong>{auction.confidentialityLabel}</strong>
+              <strong>{auction.bidLaneLabel}</strong>
             </article>
           </div>
           <p className="detail-callout">{auction.settlementNote}</p>
@@ -105,7 +105,7 @@ export default async function AuctionDetailsPage({ params }: AuctionDetailsPageP
         auctionId={auction.id}
         auctionState={auction.state}
         auctionTitle={auction.title}
-        confidentialityLabel={auction.confidentialityLabel}
+        bidLaneLabel={auction.bidLaneLabel}
         escrowLabel={auction.escrowLabel}
         onChain={auction.onChain}
         openingBidAmount={auction.openingBidAmount}
@@ -145,8 +145,8 @@ export default async function AuctionDetailsPage({ params }: AuctionDetailsPageP
               </p>
             </div>
             <div>
-              <span className="detail-label">Confidentiality</span>
-              <h2 className="detail-card__value">{auction.confidentialityLabel}</h2>
+              <span className="detail-label">Prototype bid lane</span>
+              <h2 className="detail-card__value">{auction.bidLaneLabel}</h2>
               <p className="detail-copy detail-card__copy">{auction.formatLabel}</p>
             </div>
           </div>

--- a/packages/frontend/src/app/marketplace/create/page.tsx
+++ b/packages/frontend/src/app/marketplace/create/page.tsx
@@ -9,7 +9,7 @@ export default function CreateAuctionPage() {
       <section className="section-block create-hero">
         <div>
           <p className="eyebrow">Create auction</p>
-          <h1 className="section-title">Create a confidential lot in four calm steps.</h1>
+          <h1 className="section-title">Create a sealed-bid prototype lot in four calm steps.</h1>
           <p className="section-note create-hero__copy">
             Start with the NFT, choose the duration, confirm the seller deposit, then review the transaction before it
             moves on chain.

--- a/packages/frontend/src/app/marketplace/page.tsx
+++ b/packages/frontend/src/app/marketplace/page.tsx
@@ -92,7 +92,7 @@ export default async function MarketplacePage({ searchParams }: MarketplacePageP
         <div className="marketplace-intro__head">
           <div>
             <p className="eyebrow">Marketplace</p>
-            <h1 className="section-title marketplace-intro__title">Explore confidential lots without the clutter.</h1>
+            <h1 className="section-title marketplace-intro__title">Explore sealed-bid prototype lots without the clutter.</h1>
             <p className="section-note marketplace-intro__copy">
               Scan the active desk quickly, open the right lot, and keep deeper protocol detail tucked away until you
               actually need it.

--- a/packages/frontend/src/app/page.tsx
+++ b/packages/frontend/src/app/page.tsx
@@ -6,7 +6,7 @@ const routeCards = [
   {
     href: "/marketplace",
     kicker: "Marketplace",
-    title: "Confidential auctions",
+    title: "Sealed-bid prototype auctions",
     description: "Browse active lots, inspect each auction clearly, and move toward escrow or bidding from one place.",
     badge: "Open now"
   },
@@ -31,13 +31,13 @@ export default function HomePage() {
     <main className="page-grid">
       <section className="hero-panel">
         <div className="hero-copy">
-          <p className="eyebrow">Sepolia-First Confidential Auction Application</p>
+          <p className="eyebrow">Sepolia-First Sealed-Bid Prototype</p>
           <div className="hero-headline">
             <h1 className="hero-title">Math-Based Integrity, operationalized.</h1>
             <HeroCrest />
           </div>
           <p className="hero-summary">
-            Browse confidential auctions, manage claims, and move through each step with a calmer interface that
+            Browse sealed-bid prototype auctions, manage claims, and move through each step with a calmer interface that
             stays focused on the action in front of you.
           </p>
           <div className="hero-actions">

--- a/packages/frontend/src/app/portfolio/page.tsx
+++ b/packages/frontend/src/app/portfolio/page.tsx
@@ -167,7 +167,7 @@ export default async function PortfolioPage() {
                     </div>
                     <StatusPill label={getAuctionStatusLabel(auction.state)} tone={getAuctionStatusTone(auction.state)} />
                   </div>
-                  <p className="portfolio-auction-card__copy">{auction.confidentialityLabel}</p>
+                  <p className="portfolio-auction-card__copy">{auction.bidLaneLabel}</p>
                   <div className="portfolio-auction-card__foot">
                     <span>{auction.timeLabel}</span>
                     <strong>{auction.nextActions[0]}</strong>

--- a/packages/frontend/src/components/auction-action-console.tsx
+++ b/packages/frontend/src/components/auction-action-console.tsx
@@ -29,7 +29,7 @@ type AuctionActionConsoleProps = {
   openingBidAmount: number;
   openingBidLabel: string;
   escrowLabel: string;
-  confidentialityLabel: string;
+  bidLaneLabel: string;
   onChain?: {
     auctionId: number;
     bidCount: number;
@@ -46,14 +46,14 @@ type AuctionActionConsoleProps = {
 const escrowStages: StageDefinition[] = [
   { label: "Signature lane", note: "User signs a payable lockEscrow request." },
   { label: "Submission", note: "The escrow transaction is sent toward the Sepolia mempool." },
-  { label: "Confirmation", note: "The escrow balance becomes available for confidential bidding." }
+  { label: "Confirmation", note: "The escrow balance becomes available for prototype sealed bidding." }
 ];
 
 const bidStages: StageDefinition[] = [
-  { label: "Client sealing", note: "Bid value is packaged into a confidential payload envelope." },
-  { label: "Signature lane", note: "User approves placeBid for the encrypted payload." },
-  { label: "Submission", note: "The encrypted bid reaches the contract surface." },
-  { label: "Stored", note: "The confidential lane is recorded and waits for settlement." }
+  { label: "Client sealing", note: "Bid value is packaged into a prototype bid envelope." },
+  { label: "Signature lane", note: "User approves placeBid for the prototype payload." },
+  { label: "Submission", note: "The prototype bid reaches the contract surface." },
+  { label: "Stored", note: "The prototype bid lane is recorded and waits for settlement." }
 ];
 
 function buildStages(definitions: StageDefinition[], activeIndex: number | null, completed = false): ActionStage[] {
@@ -129,8 +129,8 @@ function getPostureMessage(state: AuctionState, isLiveAuction: boolean, closeWin
       }
 
       return isLiveAuction
-        ? "This lot is open for real on-chain escrow locking and confidential bidding right now."
-        : "This lot is open for escrow staging and confidential bidding.";
+        ? "This lot is open for real on-chain escrow locking and prototype sealed bidding right now."
+        : "This lot is open for escrow staging and prototype sealed bidding.";
   }
 }
 
@@ -141,7 +141,7 @@ export function AuctionActionConsole({
   openingBidAmount,
   openingBidLabel,
   escrowLabel,
-  confidentialityLabel,
+  bidLaneLabel,
   onChain
 }: AuctionActionConsoleProps) {
   const wallet = useWallet();
@@ -154,7 +154,7 @@ export function AuctionActionConsole({
   const [isRefreshingWalletEscrow, setIsRefreshingWalletEscrow] = useState(false);
   const [isRunning, setIsRunning] = useState(false);
   const [headline, setHeadline] = useState("Choose your next action");
-  const [note, setNote] = useState("Connect on Sepolia, add escrow, then continue to a confidential bid.");
+  const [note, setNote] = useState("Connect on Sepolia, add escrow, then continue to a prototype sealed bid.");
   const [notice, setNotice] = useState<string | null>(null);
   const [lastReceipt, setLastReceipt] = useState<string | null>(null);
   const [stages, setStages] = useState<ActionStage[]>(buildStages(escrowStages, null));
@@ -228,15 +228,15 @@ export function AuctionActionConsole({
 
     startTransition(() => {
       setMode(nextMode);
-      setHeadline(nextMode === "escrow" ? "Add escrow first" : "Seal a confidential bid");
+      setHeadline(nextMode === "escrow" ? "Add escrow first" : "Seal a prototype bid");
       setNote(
         nextMode === "escrow"
           ? isLiveAuction
             ? "Lock real escrow on chain before expecting seller cancellation or refund logic to see it."
-            : "Escrow must be added before confidential bidding can open for this lot."
+            : "Escrow must be added before prototype sealed bidding can open for this lot."
           : isLiveAuction
-            ? "The escrow lane is live on chain. Once your wallet escrow covers the amount, you can submit the confidential bid directly from here."
-            : "A confidential bid becomes available after you have enough escrow in place."
+            ? "The escrow lane is live on chain. Once your wallet escrow covers the amount, you can submit the prototype bid directly from here."
+            : "A prototype bid becomes available after you have enough escrow in place."
       );
       setNotice(null);
       resetStageRail(nextMode);
@@ -337,7 +337,7 @@ export function AuctionActionConsole({
       setStages(buildStages(escrowStages, null, true));
       setStagedEscrow((current) => current + amount);
       setHeadline("Escrow added");
-      setNote("You can now continue to the confidential bid step for this lot.");
+      setNote("You can now continue to the prototype bid step for this lot.");
       setLastReceipt(`Escrow prepared for ${formatEth(amount)} on ${auctionTitle}.`);
       startTransition(() => {
         setMode("bid");
@@ -370,7 +370,7 @@ export function AuctionActionConsole({
 
       const amountWei = parseEther(bidInput);
       if (availableWalletEscrowWei === 0n) {
-        setNotice("Lock escrow first before submitting a confidential bid.");
+        setNotice("Lock escrow first before submitting a prototype bid.");
         return;
       }
       if (amountWei > availableWalletEscrowWei) {
@@ -380,8 +380,8 @@ export function AuctionActionConsole({
 
       setIsRunning(true);
       setNotice(null);
-      setHeadline("Submitting confidential bid");
-      setNote("Preparing the confidential bid envelope and waiting for the on-chain confirmation trail.");
+      setHeadline("Submitting prototype bid");
+      setNote("Preparing the prototype bid envelope and waiting for the on-chain confirmation trail.");
       setLastReceipt(null);
 
       try {
@@ -406,13 +406,13 @@ export function AuctionActionConsole({
         });
 
         setStages(buildStages(bidStages, null, true));
-        setHeadline("Confidential bid stored");
-        setNote("The encrypted bid handle is now recorded on chain and will only matter again once settlement starts.");
-        setLastReceipt(`Confidential bid submitted for ${formatEth(amount)} on ${auctionTitle}.`);
+        setHeadline("Prototype bid stored");
+        setNote("The prototype bid handle is now recorded on chain and will only matter again once settlement starts.");
+        setLastReceipt(`Prototype bid submitted for ${formatEth(amount)} on ${auctionTitle}.`);
         setWalletEscrowWei(result.walletEscrowWei);
         router.refresh();
       } catch (error) {
-        setNotice(error instanceof Error ? error.message : "Confidential bid submission failed.");
+        setNotice(error instanceof Error ? error.message : "Prototype bid submission failed.");
         resetStageRail("bid");
       } finally {
         setIsRunning(false);
@@ -429,7 +429,7 @@ export function AuctionActionConsole({
     }
 
     if (stagedEscrow <= 0) {
-      setNotice("Add escrow first before continuing to a confidential bid.");
+      setNotice("Add escrow first before continuing to a prototype bid.");
       return;
     }
 
@@ -444,15 +444,15 @@ export function AuctionActionConsole({
 
     setIsRunning(true);
     setNotice(null);
-    setHeadline("Sealing confidential bid");
-    setNote("Preparing the confidential bid and moving it through the submission steps.");
+    setHeadline("Sealing prototype bid");
+    setNote("Preparing the prototype bid and moving it through the submission steps.");
     setLastReceipt(null);
 
     try {
       await runStageSequence(bidStages);
-      setHeadline("Confidential bid prepared");
+      setHeadline("Prototype bid prepared");
       setNote("Your bid is sealed and ready for the normal settlement path.");
-      setLastReceipt(`Confidential bid prepared for ${formatEth(amount)} on ${auctionTitle}.`);
+      setLastReceipt(`Prototype bid prepared for ${formatEth(amount)} on ${auctionTitle}.`);
     } finally {
       setIsRunning(false);
     }
@@ -464,7 +464,7 @@ export function AuctionActionConsole({
         ? "Lock escrow on chain"
         : "Add escrow"
       : isLiveAuction
-        ? "Place confidential bid"
+        ? "Place prototype bid"
         : "Seal bid";
 
   return (
@@ -472,7 +472,7 @@ export function AuctionActionConsole({
       <div className="section-header">
         <div>
           <p className="eyebrow">Actions</p>
-          <h2 className="section-title">Escrow first. Confidential bid second.</h2>
+          <h2 className="section-title">Escrow first. Prototype bid second.</h2>
         </div>
       </div>
 
@@ -493,7 +493,7 @@ export function AuctionActionConsole({
               onClick={() => handleSwitchMode("bid")}
               type="button"
             >
-              Confidential Bid
+              Prototype Bid
             </button>
           </div>
 
@@ -528,7 +528,7 @@ export function AuctionActionConsole({
               />
               <p className="detail-copy">
                 {!wallet.hasProvider
-                  ? "An injected wallet is required before the encrypted action lane can open."
+                  ? "An injected wallet is required before the prototype action lane can open."
                   : !wallet.isConnected
                     ? "Connect a wallet first before continuing."
                     : "This action is currently available on Sepolia."}
@@ -570,7 +570,7 @@ export function AuctionActionConsole({
                   <p className="action-console__hint">
                     {isLiveAuction
                       ? "This button sends a real payable lockEscrow transaction. Once it confirms, seller cancellation and refund routes will read the same on-chain escrow."
-                      : "A payable escrow lock must land before any confidential bid can be accepted for this auction."}
+                      : "A payable escrow lock must land before any prototype bid can be accepted for this auction."}
                   </p>
                   <button
                     className="primary-action action-console__cta"
@@ -596,8 +596,8 @@ export function AuctionActionConsole({
                   </div>
                   <p className="action-console__hint">
                     {isLiveAuction
-                      ? "This button submits a real on-chain confidential bid handle. Make sure this wallet already locked enough escrow first."
-                      : `${confidentialityLabel}. Add enough escrow first, then seal the bid amount you want to submit.`}
+                      ? "This button submits a prototype on-chain bid handle. Make sure this wallet already locked enough escrow first."
+                      : `${bidLaneLabel}. Add enough escrow first, then seal the bid amount you want to submit.`}
                   </p>
                   <button
                     className="primary-action action-console__cta"

--- a/packages/frontend/src/components/auction-card.tsx
+++ b/packages/frontend/src/components/auction-card.tsx
@@ -46,7 +46,7 @@ export function AuctionCard({ auction }: AuctionCardProps) {
 
       <div className="auction-card__body">
         <div className="auction-card__headline">
-          <p className="auction-card__eyebrow">{auction.confidentialityLabel}</p>
+          <p className="auction-card__eyebrow">{auction.bidLaneLabel}</p>
           <h2 className="auction-card__title">{auction.title}</h2>
         </div>
 

--- a/packages/frontend/src/components/auction-settlement-controls.tsx
+++ b/packages/frontend/src/components/auction-settlement-controls.tsx
@@ -95,7 +95,7 @@ export function AuctionSettlementControls({
     if (effectiveState === "active" && closeWindowReached) {
       return onChain.bidCount > 0
         ? "The bidding window is over. Start settlement now so the keeper and AVS path can resolve the winner."
-        : "The bidding window is over, but no on-chain confidential bid was recorded. Start settlement to finalize the no-winner branch and let the seller reclaim the NFT.";
+        : "The bidding window is over, but no on-chain prototype bid was recorded. Start settlement to finalize the no-winner branch and let the seller reclaim the NFT.";
     }
 
     if (effectiveState === "resolving") {

--- a/packages/frontend/src/components/brand-lockup.tsx
+++ b/packages/frontend/src/components/brand-lockup.tsx
@@ -35,7 +35,7 @@ export function BrandLockup() {
       </div>
       <div className="brand-footnote">
         <div>
-          <strong>Confidential flow</strong>
+          <strong>Prototype flow</strong>
           Escrow first. Sealed bids next.
         </div>
         <div>

--- a/packages/frontend/src/components/create-auction-form.tsx
+++ b/packages/frontend/src/components/create-auction-form.tsx
@@ -173,7 +173,7 @@ function getWalletStatus(wallet: ReturnType<typeof useWallet>, marketReady: bool
 }
 
 function getFormatLabel(format: CreateAuctionFormState["format"]) {
-  return format === "vickrey" ? "Vickrey sealed bid" : "Confidential auction";
+  return format === "vickrey" ? "Vickrey sealed bid" : "Prototype sealed auction";
 }
 
 export function CreateAuctionForm() {
@@ -447,7 +447,7 @@ export function CreateAuctionForm() {
                 value={form.format}
               >
                 <option value="vickrey">Vickrey sealed bid</option>
-                <option value="standard">Confidential auction</option>
+                <option value="standard">Prototype sealed auction</option>
               </select>
             </label>
           </div>

--- a/packages/frontend/src/components/marketplace-grid-client.tsx
+++ b/packages/frontend/src/components/marketplace-grid-client.tsx
@@ -20,7 +20,7 @@ export function MarketplaceGridClient({ auctions }: MarketplaceGridClientProps) 
           <StatusPill label="No lots in this slice" tone="warning" />
           <h2 className="placeholder-title">This desk is quiet right now.</h2>
           <p className="placeholder-copy">
-            Change the filter or create a new confidential auction to see more activity here.
+            Change the filter or create a new sealed-bid prototype auction to see more activity here.
           </p>
           <div className="hero-actions">
             <Link className="secondary-action" href="/marketplace">

--- a/packages/frontend/src/lib/auctions.ts
+++ b/packages/frontend/src/lib/auctions.ts
@@ -11,7 +11,7 @@ export type AuctionRecord = {
   lotLabel: string;
   state: AuctionState;
   formatLabel: string;
-  confidentialityLabel: string;
+  bidLaneLabel: string;
   seller: string;
   sellerTag: string;
   openingBidAmount: number;
@@ -102,7 +102,7 @@ const auctionSeed: AuctionRecord[] = [
     lotLabel: "Lot 091 / sealed opening",
     state: "active",
     formatLabel: "Sealed bid",
-    confidentialityLabel: "Encrypted bid lane open",
+    bidLaneLabel: "Prototype bid lane open",
     seller: "0x8A4d...72C1",
     sellerTag: "Treasury curator",
     openingBidAmount: 3.2,
@@ -110,7 +110,7 @@ const auctionSeed: AuctionRecord[] = [
     escrowLabel: "11.80 ETH escrow locked",
     timeLabel: "03h 41m left",
     synopsis:
-      "A high-interest vault relic prepared for confidential bidding with clear terms and strong seller coverage.",
+      "A high-interest vault relic prepared for prototype sealed bidding with clear terms and strong seller coverage.",
     settlementNote: "Settlement begins as soon as the bidding window closes.",
     visual: {
       halo: "rgba(141, 107, 255, 0.72)",
@@ -123,7 +123,7 @@ const auctionSeed: AuctionRecord[] = [
       { label: "Participants", value: "07 active" },
       { label: "Settlement", value: "Protected close" }
     ],
-    nextActions: ["Lock escrow", "Place confidential bid", "Review lot details"],
+    nextActions: ["Lock escrow", "Place prototype bid", "Review lot details"],
     timeline: [
       { label: "Asset intake", value: "NFT custody verified", tone: "success" },
       { label: "Auction state", value: "Open for encrypted bids", tone: "success" },
@@ -142,10 +142,10 @@ const auctionSeed: AuctionRecord[] = [
     id: "helios-index-144",
     title: "Helios Index",
     collection: "Quant Frames",
-    lotLabel: "Lot 144 / confidential treasury release",
+    lotLabel: "Lot 144 / sealed-bid prototype release",
     state: "active",
     formatLabel: "Sealed bid",
-    confidentialityLabel: "Bid lane gated by escrow",
+    bidLaneLabel: "Bid lane gated by escrow",
     seller: "0xB163...D8A0",
     sellerTag: "Protocol partner",
     openingBidAmount: 2.45,
@@ -166,7 +166,7 @@ const auctionSeed: AuctionRecord[] = [
       { label: "Participants", value: "05 active" },
       { label: "Settlement", value: "Keeper tracked" }
     ],
-    nextActions: ["Add more escrow", "Place confidential bid", "Wait for settlement"],
+    nextActions: ["Add more escrow", "Place prototype bid", "Wait for settlement"],
     timeline: [
       { label: "Asset intake", value: "Metadata synced", tone: "success" },
       { label: "Auction state", value: "Accepting encrypted bids", tone: "success" },
@@ -188,7 +188,7 @@ const auctionSeed: AuctionRecord[] = [
     lotLabel: "Lot 208 / resolving sequence",
     state: "resolving",
     formatLabel: "Asynchronous settlement",
-    confidentialityLabel: "Decryption request in-flight",
+    bidLaneLabel: "Decryption request in-flight",
     seller: "0x71b0...A4C5",
     sellerTag: "Independent seller",
     openingBidAmount: 1.9,
@@ -196,7 +196,7 @@ const auctionSeed: AuctionRecord[] = [
     escrowLabel: "6.42 ETH escrow locked",
     timeLabel: "Keeper resolving now",
     synopsis:
-      "The bid window has closed and the lot is now moving through confidential settlement.",
+      "The bid window has closed and the lot is now moving through prototype settlement.",
     settlementNote: "Refunds and seller proceeds stay locked until the proof comes back.",
     visual: {
       halo: "rgba(101, 255, 207, 0.64)",
@@ -217,7 +217,7 @@ const auctionSeed: AuctionRecord[] = [
     ],
     protocolSignals: [
       "Finalization request already recorded on-chain.",
-      "Winner selection remains confidential until settlement completes.",
+      "Winner selection remains sealed until settlement completes.",
       "Keeper reward becomes claimable after completion."
     ],
     activityScore: 9,
@@ -230,8 +230,8 @@ const auctionSeed: AuctionRecord[] = [
     collection: "Oracle Geometry",
     lotLabel: "Lot 313 / final settlement complete",
     state: "finalized",
-    formatLabel: "Confidential close complete",
-    confidentialityLabel: "Winner committed",
+    formatLabel: "Sealed-bid close complete",
+    bidLaneLabel: "Winner committed",
     seller: "0xD912...331F",
     sellerTag: "Verified seller",
     openingBidAmount: 4.1,
@@ -274,7 +274,7 @@ const auctionSeed: AuctionRecord[] = [
     lotLabel: "Lot 402 / guarded rollback",
     state: "voided",
     formatLabel: "Fallback void",
-    confidentialityLabel: "No winner committed",
+    bidLaneLabel: "No winner committed",
     seller: "0xA4F1...9907",
     sellerTag: "Seller under fallback review",
     openingBidAmount: 2.1,
@@ -317,7 +317,7 @@ const auctionSeed: AuctionRecord[] = [
     lotLabel: "Lot 119 / active competitive desk",
     state: "active",
     formatLabel: "Sealed bid",
-    confidentialityLabel: "Escrow threshold satisfied",
+    bidLaneLabel: "Escrow threshold satisfied",
     seller: "0x4340...AB12",
     sellerTag: "Archive steward",
     openingBidAmount: 5.6,
@@ -338,7 +338,7 @@ const auctionSeed: AuctionRecord[] = [
       { label: "Participants", value: "11 active" },
       { label: "Settlement", value: "Priority close" }
     ],
-    nextActions: ["Place confidential bid", "Track close window", "Review auction details"],
+    nextActions: ["Place prototype bid", "Track close window", "Review auction details"],
     timeline: [
       { label: "Asset intake", value: "Ready", tone: "success" },
       { label: "Auction state", value: "High-traffic active desk", tone: "success" },
@@ -421,12 +421,12 @@ export function getAuctionStatusLabel(state: AuctionState) {
 
 export function getMarketplaceStats(records: AuctionRecord[]) {
   const activeCount = records.filter((auction) => auction.state === "active").length;
-  const confidentialCount = records.filter((auction) => auction.onChain).length;
+  const prototypeCount = records.filter((auction) => auction.onChain).length;
   const resolvingCount = records.filter((auction) => auction.state === "resolving").length;
 
   return [
     {
-      label: "Confidential lots",
+      label: "Prototype lots",
       value: `${records.length} listed`,
       note: "Curated across the current Sepolia desk."
     },
@@ -442,7 +442,7 @@ export function getMarketplaceStats(records: AuctionRecord[]) {
     },
     {
       label: "Live actions",
-      value: `${activeCount} active / ${confidentialCount} confidential`,
+      value: `${activeCount} active / ${prototypeCount} prototype`,
       note: "Only settlement state and route readiness stay visible on the public desk."
     }
   ] as const;
@@ -545,7 +545,7 @@ export function getUserOperations(): UserOperationRecord {
         id: "activity-001",
         timestamp: "2m ago",
         title: "Escrow staged for Sable Atlas",
-        detail: "You opened a 1.20 ETH local escrow lane before confidential bid submission.",
+        detail: "You opened a 1.20 ETH local escrow lane before prototype bid submission.",
         tone: "success"
       },
       {

--- a/packages/frontend/src/lib/live-auction-actions.ts
+++ b/packages/frontend/src/lib/live-auction-actions.ts
@@ -12,6 +12,7 @@ const marketInterface = new Interface([
 const CIPHERTEXT_KIND_SHIFT = 248n;
 const EUINT96_KIND = 3n;
 const MAX_EUINT96_VALUE = (1n << 96n) - 1n;
+const LOCAL_PROTOTYPE_CHAIN_IDS = new Set(["0x539", "0x7a69"]);
 
 type JsonRpcReceipt = {
   status?: string;
@@ -62,9 +63,15 @@ function toHexQuantity(value: bigint) {
   return `0x${value.toString(16)}`;
 }
 
+async function readChainId(provider: Eip1193Provider) {
+  return ((await provider.request({
+    method: "eth_chainId"
+  })) as string).toLowerCase();
+}
+
 function encodeEuint96(value: bigint) {
   if (value < 0n || value > MAX_EUINT96_VALUE) {
-    throw new Error("Bid amount is outside the supported encrypted range.");
+    throw new Error("Bid amount is outside the current prototype bid-handle range.");
   }
 
   const encoded = (EUINT96_KIND << CIPHERTEXT_KIND_SHIFT) | value;
@@ -139,6 +146,17 @@ async function waitForReceipt(provider: Eip1193Provider, txHash: string, timeout
   }
 
   throw new Error("Transaction confirmation timed out.");
+}
+
+async function assertPrototypeBidPathAllowed(provider: Eip1193Provider) {
+  const chainId = await readChainId(provider);
+  if (LOCAL_PROTOTYPE_CHAIN_IDS.has(chainId)) {
+    return;
+  }
+
+  throw new Error(
+    "Prototype wallet bidding is disabled on this network until real CoFHE ciphertext-input support is wired into the frontend."
+  );
 }
 
 async function readEncryptedBidWithWallet(
@@ -236,10 +254,12 @@ export async function placeBidWithWallet({
 }: PlaceBidParams): Promise<PlaceBidResult> {
   const normalizedAccount = getAddress(account);
   const normalizedMarketAddress = getAddress(marketAddress);
-  const encryptedBid = encodeEuint96(amountWei);
 
   try {
-    onProgress?.("Preparing the confidential bid envelope...");
+    await assertPrototypeBidPathAllowed(provider);
+
+    const encryptedBid = encodeEuint96(amountWei);
+    onProgress?.("Preparing the local prototype bid envelope...");
     onProgress?.("Confirm the bid transaction in your wallet...");
     const txHash = await sendTransaction(provider, {
       from: normalizedAccount,
@@ -250,7 +270,7 @@ export async function placeBidWithWallet({
     onProgress?.("Waiting for the bid transaction confirmation...");
     const receipt = await waitForReceipt(provider, txHash);
     if (receipt.status !== "0x1") {
-      throw new Error("Confidential bid submission did not complete successfully.");
+      throw new Error("Prototype bid submission did not complete successfully.");
     }
 
     const [storedBid, walletEscrow] = await Promise.all([
@@ -259,10 +279,10 @@ export async function placeBidWithWallet({
     ]);
 
     if (storedBid.toLowerCase() !== encryptedBid.toLowerCase()) {
-      throw new Error("The encrypted bid was not stored on chain as expected.");
+      throw new Error("The prototype bid handle was not stored on chain as expected.");
     }
 
-    onProgress?.("Confidential bid stored on chain.");
+    onProgress?.("Local prototype bid handle stored on chain.");
     return {
       encryptedBid,
       txHash,

--- a/packages/frontend/src/lib/marketplace-data.ts
+++ b/packages/frontend/src/lib/marketplace-data.ts
@@ -522,16 +522,16 @@ function hasCloseWindowEnded(endTime: bigint, nowUnix: number) {
 function getAuctionSynopsis(state: AuctionState, collectionLabel: string) {
   switch (state) {
     case "resolving":
-      return `${collectionLabel} already moved beyond bidding and is now waiting for confidential settlement to complete.`;
+      return `${collectionLabel} already moved beyond bidding and is now waiting for prototype settlement to complete.`;
     case "finalized":
-      return `${collectionLabel} completed its confidential path and is now ready for post-settlement claims.`;
+      return `${collectionLabel} completed its sealed-bid path and is now ready for post-settlement claims.`;
     case "voided":
       return `${collectionLabel} moved into a guarded cancellation path and now exposes refund-oriented actions.`;
     case "cancelled":
       return `${collectionLabel} was cancelled by the seller before close, and the recovery path is now focused on refunds plus seller payout settlement.`;
     case "active":
     default:
-      return `${collectionLabel} is live on Sepolia and can accept escrow plus confidential bidding actions from compatible wallets.`;
+      return `${collectionLabel} is live on Sepolia and can accept escrow plus prototype bidding actions from compatible wallets.`;
   }
 }
 
@@ -575,13 +575,13 @@ function getProtocolSignals(state: AuctionState, bidCount: bigint, hasEnded: boo
       return [
         "The close window is over and the resolution proof is now in-flight.",
         "The public desk hides live escrow magnitudes during sealed-bid settlement.",
-        `${bidCount.toString()} confidential bid lane(s) were recorded before the close window ended.`
+        `${bidCount.toString()} prototype bid lane(s) were recorded before the close window ended.`
       ];
     case "finalized":
       return [
         "The winner and payout path are already fixed on chain.",
         "The public desk stays focused on settlement state instead of exposing private auction sizing.",
-        `${bidCount.toString()} confidential bid lane(s) fed into the final outcome.`
+        `${bidCount.toString()} prototype bid lane(s) fed into the final outcome.`
       ];
     case "voided":
       return [
@@ -605,8 +605,8 @@ function getProtocolSignals(state: AuctionState, bidCount: bigint, hasEnded: boo
           ? "The next safe step is to start settlement from the auction details page."
           : "The public desk intentionally hides live escrow magnitudes for sealed-bid lots.",
         bidCount > 0n
-          ? `${bidCount.toString()} confidential bid lane(s) are already recorded on chain.`
-          : "No on-chain confidential bid has been recorded yet."
+          ? `${bidCount.toString()} prototype bid lane(s) are already recorded on chain.`
+          : "No on-chain prototype bid has been recorded yet."
       ];
   }
 }
@@ -672,7 +672,7 @@ function buildTimeline(
     {
       label: "Bid lanes",
       tone: bidCount > 0n ? ("success" as const) : ("neutral" as const),
-      value: `${bidCount.toString()} confidential lane(s) recorded`
+      value: `${bidCount.toString()} prototype lane(s) recorded`
     }
   ];
 }
@@ -690,10 +690,10 @@ function buildLiveAuctionRecord(
   const state = mapLiveAuctionState(core.state);
   const hasEnded = state === "active" && hasCloseWindowEnded(core.endTime, nowUnix);
   const lotLabel = `Lot #${auctionId} / token ${core.tokenId.toString()}`;
-  const formatLabel = core.isVickrey ? "Vickrey sealed bid" : "Confidential auction";
+  const formatLabel = core.isVickrey ? "Vickrey sealed bid" : "Prototype sealed auction";
   const openingBidLabel =
     startingPrice > 0n
-      ? "Confidential floor configured"
+      ? "Prototype floor configured"
       : state === "active"
         ? "No public opening bid"
         : "Opening price remained private";
@@ -702,10 +702,10 @@ function buildLiveAuctionRecord(
       ? hasEnded
         ? "Close window reached. Settlement can start now."
         : phase2.bidCount > 0n
-          ? "Confidential participation recorded"
+          ? "Prototype participation recorded"
           : "No public bidder activity"
       : state === "resolving"
-        ? "Confidential settlement in progress"
+        ? "Prototype settlement in progress"
         : state === "finalized"
           ? "Settlement complete"
           : state === "cancelled"
@@ -728,12 +728,12 @@ function buildLiveAuctionRecord(
     activityScore: Number(phase2.bidCount),
     artwork,
     collection: collectionName,
-    confidentialityLabel:
+    bidLaneLabel:
       state === "active" && hasEnded
         ? "Closed"
         : core.isVickrey
-          ? "Encrypted Vickrey lane active"
-          : "Confidential bidding lane active",
+          ? "Prototype Vickrey lane active"
+          : "Prototype bidding lane active",
     escrowLabel: publicEscrowLabel,
     escrowScore: Number.parseFloat(formatEther(core.sellerDeposit + phase2.totalEscrow)),
     formatLabel,

--- a/packages/frontend/src/lib/reliability.ts
+++ b/packages/frontend/src/lib/reliability.ts
@@ -35,7 +35,7 @@ export type MobileReadinessPoint = {
 export const protocolSignals: ProtocolSignal[] = [
   {
     label: "Settlement",
-    value: "Confidential until completion",
+    value: "Sealed until completion",
     tone: "success",
     note: "Winner selection stays hidden until the auction is fully resolved."
   },


### PR DESCRIPTION
## Summary
- Add SECURITY_STATUS.md as the current security source of truth.
- Mark the current CofheAdapter path as prototype/local-development only.
- Block prototype adapter deployment on non-local networks.
- Replace frontend production-confidential language with prototype/review wording.

## Validation
- pnpm --filter frontend build
- pnpm --filter contracts compile
