### PR TITLE
fix(security): disable legacy witness claim paths

### DIFF
--- a/packages/contracts/contracts/core/FhenixFairMarket.sol
+++ b/packages/contracts/contracts/core/FhenixFairMarket.sol
@@ -72,6 +72,7 @@ contract FhenixFairMarket is
     error InvalidDuration(uint256 providedDuration);
     error InvalidStateTransition(AuctionState fromState, AuctionState toState);
     error AssetAlreadyClaimed(uint256 auctionId);
+    error LegacyWitnessClaimsDisabled();
     error BidBelowStartingPrice(uint256 auctionId, address bidder, uint256 requiredMinimum);
     error BidExceedsEscrow(uint256 auctionId, address bidder);
     error FinalizeRewardAlreadyClaimed(uint256 auctionId);
@@ -734,29 +735,10 @@ contract FhenixFairMarket is
 
     function claimShieldedAsset(uint256 auctionId, bytes32 secret, bytes32 nullifier, address recipient)
         external
-        nonReentrant
-        auctionExists(auctionId)
-        onlyAuctionState(auctionId, AuctionState.FINALIZED)
+        pure
     {
-        Auction storage auction = _auctions[auctionId];
-        if (auction.assetClaimed) {
-            revert AssetAlreadyClaimed(auctionId);
-        }
-        if (recipient == address(0)) {
-            revert ZeroAddress();
-        }
-
-        bytes32 winningIdentityHash = _winningCommitments[auctionId];
-        bytes32 expectedCommitmentHash = _resolveShieldedCommitment(auctionId, winningIdentityHash);
-        bytes32 providedCommitmentHash = keccak256(abi.encodePacked(secret, nullifier));
-        if (expectedCommitmentHash == bytes32(0) || providedCommitmentHash != expectedCommitmentHash) {
-            revert UnauthorizedShieldedAssetClaim(auctionId, providedCommitmentHash, expectedCommitmentHash);
-        }
-
-        auction.assetClaimed = true;
-        NFTGuard.releaseFromEscrow(auction.nftContract, address(this), recipient, auction.tokenId);
-
-        emit AssetClaimed(auctionId, recipient, auction.tokenId);
+        (auctionId, secret, nullifier, recipient);
+        revert LegacyWitnessClaimsDisabled();
     }
 
     function claimShieldedAssetWithAuthorization(

--- a/packages/contracts/contracts/interfaces/IShieldedEscrowVault.sol
+++ b/packages/contracts/contracts/interfaces/IShieldedEscrowVault.sol
@@ -2,6 +2,8 @@
 pragma solidity ^0.8.25;
 
 interface IShieldedEscrowVault {
+    error LegacyWitnessClaimsDisabled();
+
     function lockEscrow(uint256 auctionId, bytes32 commitmentHash, address claimAuthority) external payable;
 
     function settleWinningCommitment(uint256 auctionId, bytes32 commitmentHash, uint256 winningAmount)
@@ -25,6 +27,7 @@ interface IShieldedEscrowVault {
 
     function claimRefund(bytes32 secret, bytes32 nullifier, address payable recipient)
         external
+        pure
         returns (uint256 principalAmount, uint256 compensationAmount);
 
     function claimRefundWithAuthorization(

--- a/packages/contracts/contracts/privacy/ShieldedEscrowVault.sol
+++ b/packages/contracts/contracts/privacy/ShieldedEscrowVault.sol
@@ -274,26 +274,11 @@ contract ShieldedEscrowVault is Ownable, ReentrancyGuard, IShieldedEscrowVault {
     function claimRefund(bytes32 secret, bytes32 nullifier, address payable recipient)
         external
         override
-        nonReentrant
+        pure
         returns (uint256 principalAmount, uint256 compensationAmount)
     {
-        if (recipient == address(0)) {
-            revert ZeroAddress();
-        }
-
-        bytes32 commitmentHash = keccak256(abi.encodePacked(secret, nullifier));
-        bytes32 nullifierHash = keccak256(abi.encodePacked(nullifier));
-        if (nullifierSpent[nullifierHash]) {
-            revert NullifierAlreadySpent(nullifierHash);
-        }
-
-        nullifierSpent[nullifierHash] = true;
-        (uint256 resolvedAuctionId, uint256 resolvedPrincipal, uint256 resolvedCompensation) =
-            _releaseRefund(commitmentHash, nullifierHash, recipient);
-
-        principalAmount = resolvedPrincipal;
-        compensationAmount = resolvedCompensation;
-        emit ShieldedRefundClaimed(resolvedAuctionId, nullifierHash, recipient, principalAmount, compensationAmount);
+        (secret, nullifier, recipient, principalAmount, compensationAmount);
+        revert LegacyWitnessClaimsDisabled();
     }
 
     function claimRefundWithAuthorization(

--- a/packages/contracts/test/unit/ShieldedBlindResolution.test.ts
+++ b/packages/contracts/test/unit/ShieldedBlindResolution.test.ts
@@ -223,7 +223,7 @@ describe("Privacy Phase 2 blind resolution", function () {
   });
 
   it("finalizes a shielded winner, routes only the winning amount into seller payout, and defers NFT reveal until claim", async function () {
-    const { adapter, avs, avsOperatorOne, avsOperatorTwo, bidder, bidderTwo, market, nft, owner, registry, seller, vault } =
+    const { adapter, avs, avsOperatorOne, avsOperatorTwo, bidder, bidderTwo, market, nft, outsider, owner, registry, seller, vault } =
       await loadFixture(createShieldedBlindFixture);
 
     const winnerNote = buildCommitment("winner");
@@ -342,6 +342,10 @@ describe("Privacy Phase 2 blind resolution", function () {
       BigInt(assetDeadline),
       winnerNote.claimAuthority
     );
+
+    await expect(
+      market.connect(outsider).claimShieldedAsset(1n, winnerNote.secret, winnerNote.nullifier, outsider.address)
+    ).to.be.revertedWithCustomError(market, "LegacyWitnessClaimsDisabled");
 
     await market
       .connect(owner)

--- a/packages/contracts/test/unit/ShieldedEscrowVault.test.ts
+++ b/packages/contracts/test/unit/ShieldedEscrowVault.test.ts
@@ -277,6 +277,48 @@ describe("ShieldedEscrowVault Privacy Phase 1", function () {
     ).to.be.revertedWithCustomError(vault, "InvalidClaimAuthority");
   });
 
+  it("blocks calldata-copyable legacy witness refund claims while authorization still works", async function () {
+    const { bidder, market, outsider, seller, settlementEngine, vault } = await loadFixture(createShieldedFixture);
+    const note = buildShieldedNote("legacy-refund-front-run");
+    const shieldedAmount = ethers.parseEther("1");
+
+    await market
+      .connect(bidder)
+      .lockShieldedEscrow(1n, note.identityHash, note.commitment, note.claimAuthority.address, { value: shieldedAmount });
+
+    const auction = await market.getAuction(1n);
+    const details = await market.getAuctionPhase2Details(1n);
+    const now = BigInt(await time.latest());
+    const createdAt = BigInt(details[3]);
+    const endTime = BigInt(auction[3]);
+    const expectedSlash = await settlementEngine.computeCancellationSlash(
+      BigInt(auction[4]),
+      now - createdAt,
+      endTime - createdAt,
+      shieldedAmount
+    );
+
+    await market.connect(seller).cancelAuction(1n);
+
+    await expect(
+      vault.connect(outsider).claimRefund(note.secret, note.nullifier, outsider.address)
+    ).to.be.revertedWithCustomError(vault, "LegacyWitnessClaimsDisabled");
+
+    const deadline = BigInt((await time.latest()) + 3600);
+    const refundSignature = await signRefundClaim(
+      await vault.getAddress(),
+      1n,
+      note.commitment,
+      bidder.address,
+      deadline,
+      note.claimAuthority
+    );
+
+    await expect(() =>
+      vault.connect(outsider).claimRefundWithAuthorization(note.commitment, bidder.address, deadline, refundSignature)
+    ).to.changeEtherBalances([vault, bidder], [-(shieldedAmount + expectedSlash), shieldedAmount + expectedSlash]);
+  });
+
   it("keeps note metadata readable without exposing raw shielded amounts to unauthorized callers", async function () {
     const { adapter, bidder, market, outsider, owner, vault } = await loadFixture(createShieldedFixture);
     const note = buildShieldedNote("preview-gate-5");


### PR DESCRIPTION
## Summary
- Disable legacy secret/nullifier refund claims.
- Disable legacy shielded asset witness claims.
- Keep authorization-based refund and asset claim paths functional.
- Add front-running regression tests for refund and NFT claim paths.

## Validation
- pnpm --filter contracts compile
- pnpm --filter contracts exec hardhat test test/unit/ShieldedEscrowVault.test.ts test/unit/ShieldedBlindResolution.test.ts
