### PR TITLE
fix(security): require verifier-backed shielded bid coverage

### DIFF
--- a/packages/contracts/contracts/interfaces/IShieldedBidVerifier.sol
+++ b/packages/contracts/contracts/interfaces/IShieldedBidVerifier.sol
@@ -7,6 +7,7 @@ interface IShieldedBidVerifier {
         uint256 auctionId,
         bytes32 commitmentHash,
         bytes32 encryptedBid,
+        uint256 committedAmount,
         uint256 deadline,
         bytes calldata proof
     ) external view returns (bool);

--- a/packages/contracts/contracts/mocks/MockShieldedBidVerifier.sol
+++ b/packages/contracts/contracts/mocks/MockShieldedBidVerifier.sol
@@ -6,12 +6,13 @@ import "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
 import "@openzeppelin/contracts/utils/cryptography/MessageHashUtils.sol";
 
 import "../interfaces/IShieldedBidVerifier.sol";
+import "../utils/CofheCiphertextEncoding.sol";
 
 contract MockShieldedBidVerifier is Ownable, IShieldedBidVerifier {
     using ECDSA for bytes32;
+    using CofheCiphertextEncoding for bytes32;
     using MessageHashUtils for bytes32;
 
-    error InvalidProver(address prover);
     error ZeroAddress();
 
     address public prover;
@@ -42,6 +43,7 @@ contract MockShieldedBidVerifier is Ownable, IShieldedBidVerifier {
         uint256 auctionId,
         bytes32 commitmentHash,
         bytes32 encryptedBid,
+        uint256 committedAmount,
         uint256 deadline,
         bytes calldata proof
     ) external view override returns (bool) {
@@ -49,14 +51,15 @@ contract MockShieldedBidVerifier is Ownable, IShieldedBidVerifier {
             revert ZeroAddress();
         }
 
-        bytes32 digest =
-            keccak256(abi.encode(address(this), block.chainid, vault, auctionId, commitmentHash, encryptedBid, deadline))
-                .toEthSignedMessageHash();
-        address recoveredProver = digest.recover(proof);
-        if (recoveredProver != prover) {
-            revert InvalidProver(recoveredProver);
+        if (encryptedBid.decodeNumeric() > committedAmount) {
+            return false;
         }
 
-        return true;
+        bytes32 digest = keccak256(
+            abi.encode(address(this), block.chainid, vault, auctionId, commitmentHash, encryptedBid, committedAmount, deadline)
+        ).toEthSignedMessageHash();
+        address recoveredProver = digest.recover(proof);
+
+        return recoveredProver == prover;
     }
 }

--- a/packages/contracts/contracts/mocks/ZkShieldedBidVerifier.sol
+++ b/packages/contracts/contracts/mocks/ZkShieldedBidVerifier.sol
@@ -2,9 +2,12 @@
 pragma solidity ^0.8.25;
 
 import "../interfaces/IShieldedBidVerifier.sol";
+import "../utils/CofheCiphertextEncoding.sol";
 import "./Verifier.sol";
 
 contract ZkShieldedBidVerifier is IShieldedBidVerifier {
+    using CofheCiphertextEncoding for bytes32;
+
     Groth16Verifier public immutable verifier;
 
     error ZeroAddress();
@@ -22,9 +25,14 @@ contract ZkShieldedBidVerifier is IShieldedBidVerifier {
         uint256,
         bytes32,
         bytes32 encryptedBid,
+        uint256 committedAmount,
         uint256,
         bytes calldata proof
     ) external view override returns (bool) {
+        if (encryptedBid.payloadOf() > committedAmount) {
+            return false;
+        }
+
         (uint256[2] memory a, uint256[2][2] memory b, uint256[2] memory c, uint256[1] memory input) =
             abi.decode(proof, (uint256[2], uint256[2][2], uint256[2], uint256[1]));
 

--- a/packages/contracts/contracts/privacy/ShieldedEscrowVault.sol
+++ b/packages/contracts/contracts/privacy/ShieldedEscrowVault.sol
@@ -23,7 +23,6 @@ contract ShieldedEscrowVault is Ownable, ReentrancyGuard, IShieldedEscrowVault {
     }
 
     bytes32 private constant _ASSET_CLAIM_TAG = keccak256("FFM_SHIELDED_ASSET_CLAIM");
-    bytes32 private constant _BID_COVERAGE_TAG = keccak256("FFM_SHIELDED_BID_COVERAGE");
     bytes32 private constant _REFUND_CLAIM_TAG = keccak256("FFM_SHIELDED_REFUND_CLAIM");
     bytes32 private constant _REFUND_COMPENSATION_TAG = keccak256("FFM_SHIELDED_REFUND_COMPENSATION");
 
@@ -338,29 +337,22 @@ contract ShieldedEscrowVault is Ownable, ReentrancyGuard, IShieldedEscrowVault {
         }
 
         address verifier = shieldedBidVerifier;
-        if (verifier != address(0)) {
-            bool valid = IShieldedBidVerifier(verifier).verifyBidCoverage(
-                address(this),
-                commitment.auctionId,
-                commitmentHash,
-                encryptedBid,
-                deadline,
-                signature
-            );
-            if (!valid) {
-                revert InvalidShieldedBidProof(commitmentHash, verifier);
-            }
-            return;
+        if (verifier == address(0)) {
+            revert InvalidShieldedBidProof(commitmentHash, address(0));
         }
 
-        _assertClaimAuthorityProof(
-            _BID_COVERAGE_TAG,
-            commitmentHash,
+        bool valid = IShieldedBidVerifier(verifier).verifyBidCoverage(
+            address(this),
             commitment.auctionId,
-            keccak256(abi.encode(encryptedBid)),
+            commitmentHash,
+            encryptedBid,
+            commitment.amount,
             deadline,
             signature
         );
+        if (!valid) {
+            revert InvalidShieldedBidProof(commitmentHash, verifier);
+        }
     }
 
     function verifyPlaintextBidCoverage(bytes32 commitmentHash, uint256 bidAmount)

--- a/packages/contracts/contracts/privacy/ShieldedEscrowVault.sol
+++ b/packages/contracts/contracts/privacy/ShieldedEscrowVault.sol
@@ -458,29 +458,6 @@ contract ShieldedEscrowVault is Ownable, ReentrancyGuard, IShieldedEscrowVault {
         _usedClaimAuthorizations[authorizationDigest] = true;
     }
 
-    function _assertClaimAuthorityProof(
-        bytes32 claimTag,
-        bytes32 commitmentHash,
-        uint256 auctionId,
-        bytes32 payloadHash,
-        uint256 deadline,
-        bytes calldata signature
-    ) internal view {
-        if (block.timestamp > deadline) {
-            revert ClaimAuthorizationExpired(deadline, block.timestamp);
-        }
-
-        CommitmentDeposit storage commitment = _requireRegisteredCommitment(commitmentHash);
-        address claimAuthority = commitment.claimAuthority;
-        bytes32 authorizationDigest =
-            keccak256(abi.encode(claimTag, block.chainid, address(this), auctionId, commitmentHash, payloadHash, deadline))
-                .toEthSignedMessageHash();
-        address recoveredAuthority = authorizationDigest.recover(signature);
-        if (recoveredAuthority != claimAuthority) {
-            revert InvalidClaimAuthority(commitmentHash, claimAuthority, recoveredAuthority);
-        }
-    }
-
     function _requireRegisteredCommitment(bytes32 commitmentHash) internal view returns (CommitmentDeposit storage commitment) {
         commitment = _commitments[commitmentHash];
         if (commitment.auctionId == 0) {

--- a/packages/contracts/test/helpers/phase3.ts
+++ b/packages/contracts/test/helpers/phase3.ts
@@ -4,8 +4,6 @@ import { AuctionMonitor } from "../../../keeper/services/auctionMonitor";
 import { AvsSubmitter } from "../../../keeper/services/avsSubmitter";
 import { CofheDispatcher, type EncryptedBidRecord } from "../../../keeper/services/cofheDispatcher";
 
-const MAX_SHIELDED_ESCROW = (1n << 96n) - 1n;
-
 export async function collectEncryptedBids(
   market: {
     getBidders(auctionId: bigint): Promise<readonly string[]>;
@@ -35,6 +33,7 @@ export async function collectShieldedEncryptedBids(
   },
   vault: {
     commitmentState(commitmentHash: string): Promise<readonly [bigint, boolean, boolean]>;
+    previewCommitment(commitmentHash: string): Promise<readonly [bigint, bigint, boolean, boolean]>;
   },
   registry: {
     identityForCommitment(auctionId: bigint, commitmentHash: string): Promise<string>;
@@ -49,11 +48,12 @@ export async function collectShieldedEncryptedBids(
     if (commitmentAuctionId !== auctionId || refundUnlocked || claimed) {
       continue;
     }
+    const [, availableEscrow] = await vault.previewCommitment(commitmentHash);
     const identityHash = registry ? await registry.identityForCommitment(auctionId, commitmentHash) : ZeroHash;
     bids.push({
       bidder: identityHash === ZeroHash ? commitmentHash : identityHash,
       encryptedBid: await market.getShieldedEncryptedBid(auctionId, commitmentHash),
-      availableEscrow: MAX_SHIELDED_ESCROW,
+      availableEscrow,
       isShielded: true
     });
   }
@@ -71,6 +71,7 @@ export async function collectAllEncryptedBids(
   },
   vault: {
     commitmentState(commitmentHash: string): Promise<readonly [bigint, boolean, boolean]>;
+    previewCommitment(commitmentHash: string): Promise<readonly [bigint, bigint, boolean, boolean]>;
   },
   registry: {
     identityForCommitment(auctionId: bigint, commitmentHash: string): Promise<string>;

--- a/packages/contracts/test/unit/ShieldedBlindResolution.test.ts
+++ b/packages/contracts/test/unit/ShieldedBlindResolution.test.ts
@@ -8,6 +8,7 @@ import { buildShieldedResolutionProof, collectAllEncryptedBids } from "../helper
 async function createShieldedBlindFixture() {
   const context = await createPhase2AuctionFixture();
   const { market, owner } = context;
+  const shieldedBidProver = ethers.Wallet.createRandom();
 
   const vaultFactory = await ethers.getContractFactory("ShieldedEscrowVault");
   const vault = await vaultFactory.deploy(owner.address);
@@ -17,8 +18,13 @@ async function createShieldedBlindFixture() {
   const registry = await registryFactory.deploy(owner.address);
   await registry.waitForDeployment();
 
+  const shieldedBidVerifierFactory = await ethers.getContractFactory("MockShieldedBidVerifier");
+  const shieldedBidVerifier = await shieldedBidVerifierFactory.deploy(owner.address, shieldedBidProver.address);
+  await shieldedBidVerifier.waitForDeployment();
+
   await vault.connect(owner).setMarket(await market.getAddress());
   await vault.connect(owner).setPreviewReader(owner.address);
+  await vault.connect(owner).setShieldedBidVerifier(await shieldedBidVerifier.getAddress());
   await registry.connect(owner).setMarket(await market.getAddress());
   await market.connect(owner).setShieldedEscrowVault(await vault.getAddress());
   await market.connect(owner).setShieldedIdentityRegistry(await registry.getAddress());
@@ -26,7 +32,9 @@ async function createShieldedBlindFixture() {
   return {
     ...context,
     vault,
-    registry
+    registry,
+    shieldedBidProver,
+    shieldedBidVerifier
   };
 }
 
@@ -82,45 +90,20 @@ async function signRefundClaim(
   return claimAuthority.signMessage(ethers.getBytes(digest));
 }
 
-async function signBidCoverage(
-  vaultAddress: string,
-  auctionId: bigint,
-  commitmentHash: string,
-  encryptedBid: string,
-  deadline: bigint,
-  claimAuthority: ethers.Wallet
-) {
-  const digest = ethers.keccak256(
-    ethers.AbiCoder.defaultAbiCoder().encode(
-      ["bytes32", "uint256", "address", "uint256", "bytes32", "bytes32", "uint256"],
-      [
-        ethers.id("FFM_SHIELDED_BID_COVERAGE"),
-        31337n,
-        vaultAddress,
-        auctionId,
-        commitmentHash,
-        ethers.keccak256(ethers.AbiCoder.defaultAbiCoder().encode(["bytes32"], [encryptedBid])),
-        deadline
-      ]
-    )
-  );
-
-  return claimAuthority.signMessage(ethers.getBytes(digest));
-}
-
 async function signVerifierCoverage(
   verifierAddress: string,
   vaultAddress: string,
   auctionId: bigint,
   commitmentHash: string,
   encryptedBid: string,
+  committedAmount: bigint,
   deadline: bigint,
   prover: ethers.Wallet
 ) {
   const digest = ethers.keccak256(
     ethers.AbiCoder.defaultAbiCoder().encode(
-      ["address", "uint256", "address", "uint256", "bytes32", "bytes32", "uint256"],
-      [verifierAddress, 31337n, vaultAddress, auctionId, commitmentHash, encryptedBid, deadline]
+      ["address", "uint256", "address", "uint256", "bytes32", "bytes32", "uint256", "uint256"],
+      [verifierAddress, 31337n, vaultAddress, auctionId, commitmentHash, encryptedBid, committedAmount, deadline]
     )
   );
 
@@ -129,22 +112,26 @@ async function signVerifierCoverage(
 
 describe("Privacy Phase 2 blind resolution", function () {
   it("stores shielded bids by commitment without polluting the public bidder registry", async function () {
-    const { adapter, bidder, market, registry, vault } = await loadFixture(createShieldedBlindFixture);
+    const { adapter, bidder, market, registry, shieldedBidProver, shieldedBidVerifier, vault } =
+      await loadFixture(createShieldedBlindFixture);
     const note = buildCommitment("shielded-bidder-one");
+    const committedAmount = 600n;
 
     await market
       .connect(bidder)
-      .lockShieldedEscrow(1n, note.identityHash, note.commitmentHash, note.claimAuthority.address, { value: 600n });
+      .lockShieldedEscrow(1n, note.identityHash, note.commitmentHash, note.claimAuthority.address, { value: committedAmount });
 
     const bidHandle = await adapter.asEuint96(450n);
     const deadline = BigInt((await time.latest()) + 3600);
-    const coverageProof = await signBidCoverage(
+    const coverageProof = await signVerifierCoverage(
+      await shieldedBidVerifier.getAddress(),
       await vault.getAddress(),
       1n,
       note.commitmentHash,
       bidHandle,
+      committedAmount,
       deadline,
-      note.claimAuthority
+      shieldedBidProver
     );
     await expect(market.connect(bidder).placeShieldedBid(1n, note.commitmentHash, bidHandle, deadline, coverageProof))
       .to.emit(market, "ShieldedBidPlaced")
@@ -168,27 +155,59 @@ describe("Privacy Phase 2 blind resolution", function () {
   });
 
   it("rejects shielded bids that do not carry a valid balance proof", async function () {
-    const { adapter, bidder, market, seller, vault } = await loadFixture(createShieldedBlindFixture);
+    const { adapter, bidder, market, seller, shieldedBidVerifier, vault } = await loadFixture(createShieldedBlindFixture);
     const note = buildCommitment("shielded-proof-reject");
+    const committedAmount = 600n;
 
     await market
       .connect(bidder)
-      .lockShieldedEscrow(1n, note.identityHash, note.commitmentHash, note.claimAuthority.address, { value: 600n });
+      .lockShieldedEscrow(1n, note.identityHash, note.commitmentHash, note.claimAuthority.address, { value: committedAmount });
 
     const bidHandle = await adapter.asEuint96(450n);
     const deadline = BigInt((await time.latest()) + 3600);
-    const forgedProof = await signBidCoverage(
+    const forgedProof = await signVerifierCoverage(
+      await shieldedBidVerifier.getAddress(),
       await vault.getAddress(),
       1n,
       note.commitmentHash,
       bidHandle,
+      committedAmount,
       deadline,
       ethers.Wallet.createRandom()
     );
 
     await expect(
       market.connect(seller).placeShieldedBid(1n, note.commitmentHash, bidHandle, deadline, forgedProof)
-    ).to.be.revertedWithCustomError(vault, "InvalidClaimAuthority");
+    ).to.be.revertedWithCustomError(vault, "InvalidShieldedBidProof");
+  });
+
+  it("rejects uncovered shielded bids before they enter the auction book", async function () {
+    const { adapter, bidder, market, shieldedBidProver, shieldedBidVerifier, vault } =
+      await loadFixture(createShieldedBlindFixture);
+    const note = buildCommitment("shielded-undercovered-reject");
+    const committedAmount = 1n;
+
+    await market
+      .connect(bidder)
+      .lockShieldedEscrow(1n, note.identityHash, note.commitmentHash, note.claimAuthority.address, { value: committedAmount });
+
+    const bidHandle = await adapter.asEuint96(450n);
+    const deadline = BigInt((await time.latest()) + 3600);
+    const coverageProof = await signVerifierCoverage(
+      await shieldedBidVerifier.getAddress(),
+      await vault.getAddress(),
+      1n,
+      note.commitmentHash,
+      bidHandle,
+      committedAmount,
+      deadline,
+      shieldedBidProver
+    );
+
+    await expect(
+      market.connect(bidder).placeShieldedBid(1n, note.commitmentHash, bidHandle, deadline, coverageProof)
+    ).to.be.revertedWithCustomError(vault, "InvalidShieldedBidProof");
+    expect(await market.getShieldedEncryptedBid(1n, note.commitmentHash)).to.equal(ethers.ZeroHash);
   });
 
   it("accepts shielded bid proofs from an external verifier boundary when configured", async function () {
@@ -206,6 +225,7 @@ describe("Privacy Phase 2 blind resolution", function () {
       .lockShieldedEscrow(1n, note.identityHash, note.commitmentHash, note.claimAuthority.address, { value: 600n });
 
     const bidHandle = await adapter.asEuint96(450n);
+    const committedAmount = 600n;
     const deadline = BigInt((await time.latest()) + 3600);
     const verifierProof = await signVerifierCoverage(
       await verifier.getAddress(),
@@ -213,6 +233,7 @@ describe("Privacy Phase 2 blind resolution", function () {
       1n,
       note.commitmentHash,
       bidHandle,
+      committedAmount,
       deadline,
       prover
     );
@@ -223,8 +244,23 @@ describe("Privacy Phase 2 blind resolution", function () {
   });
 
   it("finalizes a shielded winner, routes only the winning amount into seller payout, and defers NFT reveal until claim", async function () {
-    const { adapter, avs, avsOperatorOne, avsOperatorTwo, bidder, bidderTwo, market, nft, outsider, owner, registry, seller, vault } =
-      await loadFixture(createShieldedBlindFixture);
+    const {
+      adapter,
+      avs,
+      avsOperatorOne,
+      avsOperatorTwo,
+      bidder,
+      bidderTwo,
+      market,
+      nft,
+      outsider,
+      owner,
+      registry,
+      seller,
+      shieldedBidProver,
+      shieldedBidVerifier,
+      vault
+    } = await loadFixture(createShieldedBlindFixture);
 
     const winnerNote = buildCommitment("winner");
     const loserNote = buildCommitment("loser");
@@ -245,21 +281,25 @@ describe("Privacy Phase 2 blind resolution", function () {
       });
 
     const bidDeadline = BigInt((await time.latest()) + 3600);
-    const winnerCoverageProof = await signBidCoverage(
+    const winnerCoverageProof = await signVerifierCoverage(
+      await shieldedBidVerifier.getAddress(),
       await vault.getAddress(),
       1n,
       winnerNote.commitmentHash,
       winnerBid,
+      600n,
       bidDeadline,
-      winnerNote.claimAuthority
+      shieldedBidProver
     );
-    const loserCoverageProof = await signBidCoverage(
+    const loserCoverageProof = await signVerifierCoverage(
+      await shieldedBidVerifier.getAddress(),
       await vault.getAddress(),
       1n,
       loserNote.commitmentHash,
       loserBid,
+      500n,
       bidDeadline,
-      loserNote.claimAuthority
+      shieldedBidProver
     );
 
     await market.connect(bidder).placeShieldedBid(1n, winnerNote.commitmentHash, winnerBid, bidDeadline, winnerCoverageProof);

--- a/packages/contracts/test/unit/ShieldedEscrowVault.test.ts
+++ b/packages/contracts/test/unit/ShieldedEscrowVault.test.ts
@@ -71,13 +71,14 @@ async function signVerifierCoverage(
   auctionId: bigint,
   commitmentHash: string,
   encryptedBid: string,
+  committedAmount: bigint,
   deadline: bigint,
   prover: ethers.Wallet
 ) {
   const digest = ethers.keccak256(
     ethers.AbiCoder.defaultAbiCoder().encode(
-      ["address", "uint256", "address", "uint256", "bytes32", "bytes32", "uint256"],
-      [verifierAddress, 31337n, vaultAddress, auctionId, commitmentHash, encryptedBid, deadline]
+      ["address", "uint256", "address", "uint256", "bytes32", "bytes32", "uint256", "uint256"],
+      [verifierAddress, 31337n, vaultAddress, auctionId, commitmentHash, encryptedBid, committedAmount, deadline]
     )
   );
 
@@ -352,7 +353,7 @@ describe("ShieldedEscrowVault Privacy Phase 1", function () {
     expect(await vault.connect(owner).verifyPlaintextBidCoverage(note.commitment, ethers.parseEther("2"))).to.equal(false);
   });
 
-  it("accepts proof-carried shielded bid coverage without revealing the note amount in the call", async function () {
+  it("rejects legacy claim-authority bid coverage proofs when no verifier is configured", async function () {
     const { adapter, bidder, market, outsider, vault } = await loadFixture(createShieldedFixture);
     const note = buildShieldedNote("proof-carried-6");
 
@@ -373,23 +374,9 @@ describe("ShieldedEscrowVault Privacy Phase 1", function () {
       note.claimAuthority
     );
 
-    await expect(vault.connect(outsider).verifyBidCoverageProof(note.commitment, encryptedBid, deadline, proof)).to.not.be
-      .reverted;
     await expect(
-      vault.connect(outsider).verifyBidCoverageProof(
-        note.commitment,
-        encryptedBid,
-        deadline,
-        await signBidCoverage(
-          await vault.getAddress(),
-          1n,
-          note.commitment,
-          encryptedBid,
-          deadline,
-          ethers.Wallet.createRandom()
-        )
-      )
-    ).to.be.revertedWithCustomError(vault, "InvalidClaimAuthority");
+      vault.connect(outsider).verifyBidCoverageProof(note.commitment, encryptedBid, deadline, proof)
+    ).to.be.revertedWithCustomError(vault, "InvalidShieldedBidProof");
   });
 
   it("can route shielded bid proofs through an external verifier boundary", async function () {
@@ -409,6 +396,7 @@ describe("ShieldedEscrowVault Privacy Phase 1", function () {
       });
 
     const encryptedBid = await adapter.asEuint96(ethers.parseEther("0.75"));
+    const committedAmount = ethers.parseEther("1");
     const deadline = BigInt((await time.latest()) + 3600);
     const verifierProof = await signVerifierCoverage(
       await verifier.getAddress(),
@@ -416,6 +404,7 @@ describe("ShieldedEscrowVault Privacy Phase 1", function () {
       1n,
       note.commitment,
       encryptedBid,
+      committedAmount,
       deadline,
       prover
     );
@@ -433,10 +422,43 @@ describe("ShieldedEscrowVault Privacy Phase 1", function () {
           1n,
           note.commitment,
           encryptedBid,
+          committedAmount,
           deadline,
           ethers.Wallet.createRandom()
         )
       )
-    ).to.be.revertedWithCustomError(verifier, "InvalidProver");
+    ).to.be.revertedWithCustomError(vault, "InvalidShieldedBidProof");
+  });
+
+  it("rejects verifier proofs when the encrypted bid exceeds committed escrow", async function () {
+    const { adapter, bidder, market, outsider, owner, vault } = await loadFixture(createShieldedFixture);
+    const note = buildShieldedNote("verifier-undercovered-8");
+    const prover = ethers.Wallet.createRandom();
+
+    const verifierFactory = await ethers.getContractFactory("MockShieldedBidVerifier");
+    const verifier = await verifierFactory.deploy(owner.address, prover.address);
+    await verifier.waitForDeployment();
+    await vault.connect(owner).setShieldedBidVerifier(await verifier.getAddress());
+
+    await market.connect(bidder).lockShieldedEscrow(1n, note.identityHash, note.commitment, note.claimAuthority.address, {
+      value: 1n
+    });
+
+    const encryptedBid = await adapter.asEuint96(450n);
+    const deadline = BigInt((await time.latest()) + 3600);
+    const verifierProof = await signVerifierCoverage(
+      await verifier.getAddress(),
+      await vault.getAddress(),
+      1n,
+      note.commitment,
+      encryptedBid,
+      1n,
+      deadline,
+      prover
+    );
+
+    await expect(
+      vault.connect(outsider).verifyBidCoverageProof(note.commitment, encryptedBid, deadline, verifierProof)
+    ).to.be.revertedWithCustomError(vault, "InvalidShieldedBidProof");
   });
 });

--- a/packages/keeper/runner.ts
+++ b/packages/keeper/runner.ts
@@ -44,14 +44,13 @@ const AVS_ABI = [
 ];
 
 const SHIELDED_VAULT_ABI = [
-  "function commitmentState(bytes32 commitmentHash) view returns (uint256 auctionId, bool refundUnlocked, bool claimed)"
+  "function commitmentState(bytes32 commitmentHash) view returns (uint256 auctionId, bool refundUnlocked, bool claimed)",
+  "function previewCommitment(bytes32 commitmentHash) view returns (uint256 auctionId, uint256 amount, bool refundUnlocked, bool claimed)"
 ];
 
 const SHIELDED_IDENTITY_REGISTRY_ABI = [
   "function identityForCommitment(uint256 auctionId, bytes32 commitmentHash) view returns (bytes32)"
 ];
-
-const MAX_SHIELDED_ESCROW = (1n << 96n) - 1n;
 
 type RuntimeMetrics = {
   activeAuctions: number;
@@ -683,6 +682,21 @@ async function collectEncryptedBidsFromChain(marketContract: Contract, auctionId
         if (commitmentAuctionId !== auctionId || refundUnlocked || claimed) {
           continue;
         }
+        let availableEscrow: bigint;
+        try {
+          const [previewAuctionId, amount, previewRefundUnlocked, previewClaimed] = (await vaultContract.previewCommitment(
+            commitmentHash
+          )) as readonly [bigint, bigint, boolean, boolean];
+          if (previewAuctionId !== auctionId || previewRefundUnlocked || previewClaimed) {
+            continue;
+          }
+          availableEscrow = BigInt(amount.toString());
+        } catch (error) {
+          console.warn(
+            `[keeper] skipped shielded commitment ${commitmentHash} for auction ${auctionId.toString()} because amount preview failed: ${normalizeError(error).message}`
+          );
+          continue;
+        }
         const identityHash =
           registryContract === undefined
             ? ZeroHash
@@ -690,7 +704,7 @@ async function collectEncryptedBidsFromChain(marketContract: Contract, auctionId
         bids.push({
           bidder: identityHash === ZeroHash ? commitmentHash : identityHash,
           encryptedBid: await marketContract.getShieldedEncryptedBid(auctionId, commitmentHash),
-          availableEscrow: MAX_SHIELDED_ESCROW,
+          availableEscrow,
           isShielded: true
         });
       }
@@ -871,6 +885,10 @@ function renderPrometheusMetrics(role: string, metrics: RuntimeMetrics): string 
     "# TYPE keeper_slashing_violations_total gauge",
     `keeper_slashing_violations_total{role="${role}"} ${metrics.slashingViolations}`
   ].join("\n");
+}
+
+function normalizeError(error: unknown): Error {
+  return error instanceof Error ? error : new Error(String(error));
 }
 
 main().catch((error) => {

--- a/packages/keeper/test/keeper.test.ts
+++ b/packages/keeper/test/keeper.test.ts
@@ -241,6 +241,36 @@ async function main(): Promise<void> {
     assert.equal(resolution.winningAmount, winningAmount);
   });
 
+  await runCase("cofhe dispatcher skips shielded bids above their available escrow", async () => {
+    const dispatcher = new CofheDispatcher(new InMemoryDispatchQueue(), () => 3_500);
+    const uncoveredAmount = 2_000n;
+    const coveredAmount = 900n;
+    const resolution = await dispatcher.dispatch({
+      auctionId: 89n,
+      requestId: "request-shielded-coverage",
+      winnerHandle: "winner-request-shielded-coverage",
+      amountHandle: "amount-request-shielded-coverage",
+      startingPrice: 1n,
+      bids: [
+        {
+          bidder: "0xshielded-undercovered",
+          encryptedBid: encodeEncryptedUint96(uncoveredAmount),
+          availableEscrow: 1n,
+          isShielded: true
+        },
+        {
+          bidder: "0xshielded-covered",
+          encryptedBid: encodeEncryptedUint96(coveredAmount),
+          availableEscrow: coveredAmount,
+          isShielded: true
+        }
+      ]
+    });
+
+    assert.equal(resolution.winner, "0xshielded-covered");
+    assert.equal(resolution.winningAmount, coveredAmount);
+  });
+
   await runCase("avs submitter aggregates signatures, validates fraud proofs, and writes symbolic slashing logs", async () => {
     const tempDirectory = await mkdtemp(path.join(os.tmpdir(), "ffm-keeper-"));
     const slashingLogPath = path.join(tempDirectory, "slashing.json");


### PR DESCRIPTION
## Summary
- Require shielded bid coverage to pass through `shieldedBidVerifier`.
- Remove `claimAuthority` self-signature as a bid balance proof.
- Bind verifier checks to the actual committed escrow amount.
- Reject undercovered shielded bids before they enter the shielded auction book.
- Update keeper bid collection to use real shielded escrow amounts instead of synthetic max escrow.
- Add regression tests for undercovered shielded bids and keeper winner selection.

## Validation
- pnpm --filter contracts compile
- pnpm --filter contracts exec hardhat test test/unit/ShieldedEscrowVault.test.ts test/unit/ShieldedBlindResolution.test.ts test/unit/ZkShieldedBidVerifier.test.ts
- pnpm --filter keeper test
