### PR TITLE
fix(security): make AVS resolution submission permissionless

### DIFF
--- a/packages/contracts/contracts/core/FhenixFairMarket.sol
+++ b/packages/contracts/contracts/core/FhenixFairMarket.sol
@@ -580,7 +580,7 @@ contract FhenixFairMarket is
         bytes32 winnerCiphertext,
         uint256 winningAmount,
         bytes calldata avsProof
-    ) external nonReentrant onlyOwner auctionExists(auctionId) onlyAuctionState(auctionId, AuctionState.RESOLVING) returns (bool) {
+    ) external nonReentrant auctionExists(auctionId) onlyAuctionState(auctionId, AuctionState.RESOLVING) returns (bool) {
         return _submitResolution(auctionId, winner, winnerCiphertext, winningAmount, avsProof);
     }
 
@@ -590,7 +590,7 @@ contract FhenixFairMarket is
         bytes32 winnerCiphertext,
         uint256 winningAmount,
         bytes calldata avsProof
-    ) external nonReentrant onlyOwner auctionExists(auctionId) onlyAuctionState(auctionId, AuctionState.RESOLVING) returns (bool) {
+    ) external nonReentrant auctionExists(auctionId) onlyAuctionState(auctionId, AuctionState.RESOLVING) returns (bool) {
         return _submitShieldedResolution(auctionId, winnerIdentityHash, winnerCiphertext, winningAmount, avsProof);
     }
 

--- a/packages/contracts/test/unit/AsyncResolution.test.ts
+++ b/packages/contracts/test/unit/AsyncResolution.test.ts
@@ -29,7 +29,7 @@ describe("Phase 2 async resolution and settlement", function () {
   });
 
   it("settles finalized auctions through pull-based refunds, seller proceeds, and deferred NFT claims", async function () {
-    const { adapter, avs, avsOperatorOne, avsOperatorTwo, bidder, bidderTwo, market, nft, owner, seller } =
+    const { adapter, avs, avsOperatorOne, avsOperatorTwo, bidder, bidderTwo, market, nft, outsider, seller } =
       await loadFixture(createPhase2AuctionFixture);
 
     await market.connect(bidder).lockEscrow(1n, { value: 600n });
@@ -48,7 +48,7 @@ describe("Phase 2 async resolution and settlement", function () {
     const { proof } = await buildPhase3ResolutionProof(market, avs, 1n, encryptedBids, [avsOperatorOne, avsOperatorTwo]);
 
     await expect(
-      market.connect(owner)["submitResolution(uint256,address,bytes32,uint256,bytes)"](
+      market.connect(outsider)["submitResolution(uint256,address,bytes32,uint256,bytes)"](
         1n,
         bidder.address,
         winnerBid,
@@ -58,6 +58,16 @@ describe("Phase 2 async resolution and settlement", function () {
     )
       .to.emit(market, "ResolutionRecorded")
       .withArgs(1n, bidder.address, winnerBid);
+
+    await expect(
+      market.connect(seller)["submitResolution(uint256,address,bytes32,uint256,bytes)"](
+        1n,
+        bidder.address,
+        winnerBid,
+        450n,
+        proof
+      )
+    ).to.be.revertedWithCustomError(market, "UnexpectedAuctionState");
 
     const winnerPreview = await market.previewRefund(1n, bidder.address);
     const runnerUpPreview = await market.previewRefund(1n, bidderTwo.address);
@@ -151,7 +161,7 @@ describe("Phase 2 async resolution and settlement", function () {
   });
 
   it("keeps the auction in resolving and slashes attesters when the submitted resolution payload is tampered with", async function () {
-    const { adapter, avs, avsOperatorOne, avsOperatorTwo, bidder, bidderTwo, market, owner } =
+    const { adapter, avs, avsOperatorOne, avsOperatorTwo, bidder, bidderTwo, market, outsider } =
       await loadFixture(createPhase2AuctionFixture);
 
     await market.connect(bidder).lockEscrow(1n, { value: 600n });
@@ -170,7 +180,7 @@ describe("Phase 2 async resolution and settlement", function () {
     ]);
 
     await expect(
-      market.connect(owner)["submitResolution(uint256,address,bytes32,uint256,bytes)"](
+      market.connect(outsider)["submitResolution(uint256,address,bytes32,uint256,bytes)"](
         1n,
         bidder.address,
         await adapter.asEuint32(450),

--- a/packages/contracts/test/unit/ShieldedBlindResolution.test.ts
+++ b/packages/contracts/test/unit/ShieldedBlindResolution.test.ts
@@ -316,7 +316,7 @@ describe("Privacy Phase 2 blind resolution", function () {
       avsOperatorTwo
     ]);
 
-    await expect(market.connect(owner).submitShieldedResolution(1n, winnerNote.identityHash, winnerBid, 450n, proof))
+    await expect(market.connect(outsider).submitShieldedResolution(1n, winnerNote.identityHash, winnerBid, 450n, proof))
       .to.emit(market, "ResolutionRecorded")
       .withArgs(1n, ethers.ZeroAddress, winnerBid);
 

--- a/packages/keeper/runner.ts
+++ b/packages/keeper/runner.ts
@@ -330,9 +330,9 @@ async function startAvsSubmitter(
 
   if (canSubmitOnChain) {
     const provider = new JsonRpcProvider(config.rpcUrl);
-    const keeperWallet = createWalletOrUndefined(process.env.PRIVATE_KEY, provider);
-    if (keeperWallet) {
-      writer = new EthersResolutionWriter(new Contract(config.marketAddress, MARKET_ABI, keeperWallet));
+    const submitterWallet = createWalletOrUndefined(process.env.PRIVATE_KEY, provider);
+    if (submitterWallet) {
+      writer = new EthersResolutionWriter(new Contract(config.marketAddress, MARKET_ABI, submitterWallet));
       digestReader = new Contract(config.avsAddress, AVS_ABI, provider);
       operatorSigners = config.avsOperatorPrivateKeys
         .filter(isValidPrivateKey)
@@ -345,7 +345,7 @@ async function startAvsSubmitter(
         );
     }
   } else {
-    console.log("[keeper] avs-submitter will observe only until market, AVS, and operator keys are configured");
+    console.log("[keeper] avs-submitter will observe only until market, AVS, operator keys, and a relayer PRIVATE_KEY are configured");
   }
 
   setInterval(async () => {


### PR DESCRIPTION
## Summary

This PR removes the owner-only bottleneck from AVS resolution submission and makes both public and shielded settlement proof submission permissionless.

The auction still keeps its existing replay and liveness protections through:
- `AuctionState.RESOLVING`
- `PendingResolutionRequest.requestId`
- request deletion on successful settlement
- state transition to `FINALIZED`

This means any valid relayer can now submit a correct AVS proof without requiring the market owner's private key.

## What changed

- remove `onlyOwner` from `submitResolution()`
- remove `onlyOwner` from `submitShieldedResolution()`
- keep request/state-based replay protection unchanged
- keep invalid or tampered proof rejection unchanged
- update keeper wording and assumptions so AVS submission is treated as a relayer path, not an owner-only path
- add regression coverage showing non-owner submission works for both public and shielded resolution flows

## Security impact

Before this PR:

- AVS resolution submission was centralized behind the owner account
- settlement liveness depended on owner-controlled submission even when the proof was valid
- keeper/operator flow could be misread as needing owner privileges for final settlement submission

After this PR:

- any non-owner relayer can submit a valid resolution proof
- invalid proof still fails
- replay after finalization still fails
- the same auction cannot be settled twice
- keeper submission no longer assumes owner-only permissions

## Acceptance mapping for Issue #6

Addresses:

- [x] `#6.1` Remove `onlyOwner` modifier from `submitResolution()`
- [x] `#6.2` Remove `onlyOwner` modifier from `submitShieldedResolution()`
- [x] `#6.3` Implement permissionless proof submission
- [x] `#6.4` Add replay protection via auction state and `requestId`
- [ ] `#6.5` (Optional) Reward first valid submitter
- [x] `#6.6` Update keeper to not require owner private key
- [x] `#6.7` Add tests for non-owner submission

## Validation

- `hardhat compile`
- `hardhat test test/unit/AsyncResolution.test.ts test/unit/ShieldedBlindResolution.test.ts test/unit/Phase4KeeperIncentives.test.ts`
- `pnpm --filter keeper test`

## Notes

This PR intentionally keeps the current incentive model unchanged.

The existing reward still belongs to the keeper that successfully calls `triggerFinalize()`.
This PR does not add a separate reward for the first valid resolution submitter.
