### PR TITLE
fix(security): snapshot auction dependencies per listing

### DIFF
--- a/packages/contracts/contracts/core/FhenixFairMarket.sol
+++ b/packages/contracts/contracts/core/FhenixFairMarket.sol
@@ -580,7 +580,7 @@ contract FhenixFairMarket is
         bytes32 winnerCiphertext,
         uint256 winningAmount,
         bytes calldata avsProof
-    ) external nonReentrant onlyOwner auctionExists(auctionId) onlyAuctionState(auctionId, AuctionState.RESOLVING) returns (bool) {
+    ) external nonReentrant auctionExists(auctionId) onlyAuctionState(auctionId, AuctionState.RESOLVING) returns (bool) {
         return _submitResolution(auctionId, winner, winnerCiphertext, winningAmount, avsProof);
     }
 
@@ -590,7 +590,7 @@ contract FhenixFairMarket is
         bytes32 winnerCiphertext,
         uint256 winningAmount,
         bytes calldata avsProof
-    ) external nonReentrant onlyOwner auctionExists(auctionId) onlyAuctionState(auctionId, AuctionState.RESOLVING) returns (bool) {
+    ) external nonReentrant auctionExists(auctionId) onlyAuctionState(auctionId, AuctionState.RESOLVING) returns (bool) {
         return _submitShieldedResolution(auctionId, winnerIdentityHash, winnerCiphertext, winningAmount, avsProof);
     }
 

--- a/packages/contracts/contracts/core/FhenixFairMarket.sol
+++ b/packages/contracts/contracts/core/FhenixFairMarket.sol
@@ -1110,17 +1110,20 @@ contract FhenixFairMarket is
             }
         }
 
-        if (
-            !auctionSettlementEngine.verifyResolutionProof(
-                address(this),
-                auctionId,
-                request.requestId,
-                winner,
-                winnerCiphertext,
-                winningAmount,
-                avsProof
-            )
-        ) {
+        // Slither cannot infer the custom nonReentrant modifier on this internal path.
+        // State is committed only after the AVS proof is accepted.
+        // slither-disable-start reentrancy-no-eth
+        // slither-disable-start reentrancy-benign
+        bool proofAccepted = auctionSettlementEngine.verifyResolutionProof(
+            address(this),
+            auctionId,
+            request.requestId,
+            winner,
+            winnerCiphertext,
+            winningAmount,
+            avsProof
+        );
+        if (!proofAccepted) {
             emit ResolutionRejected(auctionId, request.requestId);
             return false;
         }
@@ -1132,6 +1135,8 @@ contract FhenixFairMarket is
         _observeNetwork();
 
         _transitionState(auctionId, AuctionState.FINALIZED);
+        // slither-disable-end reentrancy-benign
+        // slither-disable-end reentrancy-no-eth
         _openShieldedRefundPath(auctionId);
         emit ResolutionRecorded(auctionId, winner, winnerCiphertext);
         return true;
@@ -1158,17 +1163,20 @@ contract FhenixFairMarket is
         bytes32 winnerCommitmentHash =
             _validateShieldedResolutionBid(auctionId, winnerIdentityHash, winnerCiphertext, winningAmount, auction.startingPrice);
 
-        if (
-            !auctionSettlementEngine.verifyShieldedResolutionProof(
-                address(this),
-                auctionId,
-                request.requestId,
-                winnerIdentityHash,
-                winnerCiphertext,
-                winningAmount,
-                avsProof
-            )
-        ) {
+        // Slither cannot infer the custom nonReentrant modifier on this internal path.
+        // State is committed only after the AVS proof is accepted.
+        // slither-disable-start reentrancy-no-eth
+        // slither-disable-start reentrancy-benign
+        bool proofAccepted = auctionSettlementEngine.verifyShieldedResolutionProof(
+            address(this),
+            auctionId,
+            request.requestId,
+            winnerIdentityHash,
+            winnerCiphertext,
+            winningAmount,
+            avsProof
+        );
+        if (!proofAccepted) {
             emit ResolutionRejected(auctionId, request.requestId);
             return false;
         }
@@ -1180,6 +1188,8 @@ contract FhenixFairMarket is
         delete _resolutionRequests[auctionId];
         _transitionState(auctionId, AuctionState.FINALIZED);
         _observeNetwork();
+        // slither-disable-end reentrancy-benign
+        // slither-disable-end reentrancy-no-eth
 
         uint256 remainingRefund = auctionVault.settleWinningCommitment(auctionId, winnerCommitmentHash, winningAmount);
         (remainingRefund);

--- a/packages/contracts/contracts/core/FhenixFairMarket.sol
+++ b/packages/contracts/contracts/core/FhenixFairMarket.sol
@@ -25,6 +25,11 @@ contract FhenixFairMarket is
 {
     using Address for address payable;
 
+    /// @custom:oz-upgrades-unsafe-allow constructor
+    constructor() {
+        _disableInitializers();
+    }
+
     enum AuctionState {
         CREATED,
         ACTIVE,
@@ -63,6 +68,15 @@ contract FhenixFairMarket is
         bytes32 winnerHandle;
         bytes32 amountHandle;
         uint64 requestedAt;
+    }
+
+    struct AuctionDependencySnapshot {
+        bool initialized;
+        address cofheAdapter;
+        address settlementEngine;
+        address slashedPot;
+        address shieldedEscrowVault;
+        address shieldedIdentityRegistry;
     }
 
     error AuctionDoesNotExist(uint256 auctionId);
@@ -159,6 +173,7 @@ contract FhenixFairMarket is
     mapping(uint256 => bytes32[]) private _shieldedCommitments;
     mapping(uint256 => bytes32) private _winningCommitments;
     IShieldedIdentityRegistry public shieldedIdentityRegistry;
+    mapping(uint256 => AuctionDependencySnapshot) private _auctionDependencySnapshots;
 
     event AuctionCreated(
         uint256 indexed auctionId,
@@ -206,6 +221,14 @@ contract FhenixFairMarket is
         bytes32 indexed requestId,
         bytes32 winnerHandle,
         bytes32 amountHandle
+    );
+    event AuctionDependencySnapshotted(
+        uint256 indexed auctionId,
+        address indexed cofheAdapter,
+        address indexed settlementEngine,
+        address slashedPot,
+        address shieldedEscrowVault,
+        address shieldedIdentityRegistry
     );
 
     modifier auctionExists(uint256 auctionId) {
@@ -366,6 +389,7 @@ contract FhenixFairMarket is
         auction.createdAt = uint64(block.timestamp);
         auction.lastBlockTimestamp = uint64(block.timestamp);
         auction.startingPrice = startingPrice;
+        _snapshotAuctionDependencies(auctionId);
 
         _observeNetwork();
         _transitionState(auctionId, AuctionState.ACTIVE);
@@ -411,6 +435,8 @@ contract FhenixFairMarket is
         auctionExists(auctionId)
         onlyAuctionState(auctionId, AuctionState.ACTIVE)
     {
+        IShieldedEscrowVault auctionVault = _auctionShieldedEscrowVault(auctionId);
+        IShieldedIdentityRegistry auctionRegistry = _auctionShieldedIdentityRegistry(auctionId);
         if (msg.value == 0) {
             revert ZeroValue();
         }
@@ -423,17 +449,17 @@ contract FhenixFairMarket is
         if (block.timestamp >= _auctions[auctionId].endTime) {
             revert AuctionAlreadyEnded(auctionId, _auctions[auctionId].endTime);
         }
-        if (address(shieldedEscrowVault).code.length < 1) {
+        if (address(auctionVault).code.length < 1) {
             revert ShieldedEscrowVaultNotConfigured();
         }
-        if (address(shieldedIdentityRegistry).code.length < 1) {
+        if (address(auctionRegistry).code.length < 1) {
             revert ShieldedIdentityRegistryNotConfigured();
         }
 
         _auctions[auctionId].lastBlockTimestamp = uint64(block.timestamp);
         _observeNetwork();
-        shieldedIdentityRegistry.bindIdentity(auctionId, identityHash, commitmentHash);
-        shieldedEscrowVault.lockEscrow{value: msg.value}(auctionId, commitmentHash, claimAuthority);
+        auctionRegistry.bindIdentity(auctionId, identityHash, commitmentHash);
+        auctionVault.lockEscrow{value: msg.value}(auctionId, commitmentHash, claimAuthority);
 
         emit ShieldedEscrowLocked(auctionId, commitmentHash, msg.value);
     }
@@ -445,6 +471,7 @@ contract FhenixFairMarket is
         onlyAuctionState(auctionId, AuctionState.ACTIVE)
     {
         Auction storage auction = _auctions[auctionId];
+        ICofheAdapter auctionAdapter = _auctionCofheAdapter(auctionId);
         if (block.timestamp >= auction.endTime) {
             revert AuctionAlreadyEnded(auctionId, auction.endTime);
         }
@@ -453,10 +480,10 @@ contract FhenixFairMarket is
         if (availableEscrow == 0) {
             revert NoEscrowLocked(auctionId, msg.sender);
         }
-        if (auction.startingPrice != 0 && !cofheAdapter.gt(encryptedBid, auction.startingPrice - 1)) {
+        if (auction.startingPrice != 0 && !auctionAdapter.gt(encryptedBid, auction.startingPrice - 1)) {
             revert BidBelowStartingPrice(auctionId, msg.sender, auction.startingPrice);
         }
-        if (!cofheAdapter.lte(encryptedBid, availableEscrow)) {
+        if (!auctionAdapter.lte(encryptedBid, availableEscrow)) {
             revert BidExceedsEscrow(auctionId, msg.sender);
         }
 
@@ -488,28 +515,30 @@ contract FhenixFairMarket is
         onlyAuctionState(auctionId, AuctionState.ACTIVE)
     {
         Auction storage auction = _auctions[auctionId];
+        IShieldedEscrowVault auctionVault = _auctionShieldedEscrowVault(auctionId);
+        ICofheAdapter auctionAdapter = _auctionCofheAdapter(auctionId);
         if (block.timestamp >= auction.endTime) {
             revert AuctionAlreadyEnded(auctionId, auction.endTime);
         }
         if (commitmentHash == bytes32(0)) {
             revert InvalidCommitmentHash();
         }
-        if (address(shieldedEscrowVault).code.length < 1) {
+        if (address(auctionVault).code.length < 1) {
             revert ShieldedEscrowVaultNotConfigured();
         }
 
         (uint256 commitmentAuctionId, bool refundUnlocked, bool claimed) =
-            shieldedEscrowVault.commitmentState(commitmentHash);
+            auctionVault.commitmentState(commitmentHash);
         if (commitmentAuctionId != auctionId || claimed) {
             revert MissingShieldedEncryptedBid(auctionId, commitmentHash);
         }
         if (refundUnlocked) {
             revert AuctionAlreadyEnded(auctionId, auction.endTime);
         }
-        if (auction.startingPrice != 0 && !cofheAdapter.gt(encryptedBid, auction.startingPrice - 1)) {
+        if (auction.startingPrice != 0 && !auctionAdapter.gt(encryptedBid, auction.startingPrice - 1)) {
             revert BidBelowStartingPrice(auctionId, msg.sender, auction.startingPrice);
         }
-        shieldedEscrowVault.verifyBidCoverageProof(commitmentHash, encryptedBid, coverageDeadline, coverageProof);
+        auctionVault.verifyBidCoverageProof(commitmentHash, encryptedBid, coverageDeadline, coverageProof);
 
         if (_shieldedEncryptedBids[auctionId][commitmentHash] == bytes32(0)) {
             auction.bidCount += 1;
@@ -622,7 +651,7 @@ contract FhenixFairMarket is
         onlyAuctionState(auctionId, AuctionState.RESOLVING)
     {
         Auction storage auction = _auctions[auctionId];
-        uint256 timeoutWindow = previewDynamicTimeout();
+        uint256 timeoutWindow = _previewDynamicTimeoutForAuction(auctionId);
         uint256 elapsed = block.timestamp - auction.resolvingSince;
         uint256 totalEscrowIncludingShielded = _totalEscrowIncludingShielded(auctionId, auction);
 
@@ -646,6 +675,7 @@ contract FhenixFairMarket is
     }
 
     function claimRefund(uint256 auctionId) external nonReentrant auctionExists(auctionId) {
+        ISlashedPot auctionSlashedPot = _auctionSlashedPot(auctionId);
         if (hasWithdrawn[auctionId][msg.sender]) {
             revert NoClaimableBalance(auctionId, msg.sender);
         }
@@ -662,7 +692,7 @@ contract FhenixFairMarket is
         }
 
         if (compensation != 0) {
-            compensation = slashedPot.claimFor(auctionId, msg.sender, escrowRefund);
+            compensation = auctionSlashedPot.claimFor(auctionId, msg.sender, escrowRefund);
         }
 
         emit RefundClaimed(auctionId, msg.sender, escrowRefund, compensation);
@@ -750,13 +780,14 @@ contract FhenixFairMarket is
         bytes calldata signature
     ) external nonReentrant auctionExists(auctionId) onlyAuctionState(auctionId, AuctionState.FINALIZED) {
         Auction storage auction = _auctions[auctionId];
+        IShieldedEscrowVault auctionVault = _auctionShieldedEscrowVault(auctionId);
         if (auction.assetClaimed) {
             revert AssetAlreadyClaimed(auctionId);
         }
         if (recipient == address(0)) {
             revert ZeroAddress();
         }
-        if (address(shieldedEscrowVault).code.length < 1) {
+        if (address(auctionVault).code.length < 1) {
             revert ShieldedEscrowVaultNotConfigured();
         }
 
@@ -768,7 +799,7 @@ contract FhenixFairMarket is
         auction.assetClaimed = true;
         bytes32 commitmentHash = _resolveShieldedCommitment(auctionId, winnerIdentityHash);
         bytes32 authorizationDigest =
-            shieldedEscrowVault.authorizeAssetClaim(auctionId, commitmentHash, recipient, deadline, signature);
+            auctionVault.authorizeAssetClaim(auctionId, commitmentHash, recipient, deadline, signature);
         (authorizationDigest);
         NFTGuard.releaseFromEscrow(auction.nftContract, address(this), recipient, auction.tokenId);
 
@@ -782,8 +813,9 @@ contract FhenixFairMarket is
         auctionExists(auctionId)
         returns (uint256 compensation)
     {
-        if (msg.sender != address(shieldedEscrowVault)) {
-            revert UnauthorizedShieldedRefundSource(msg.sender, address(shieldedEscrowVault));
+        IShieldedEscrowVault auctionVault = _auctionShieldedEscrowVault(auctionId);
+        if (msg.sender != address(auctionVault)) {
+            revert UnauthorizedShieldedRefundSource(msg.sender, address(auctionVault));
         }
         if (_shieldedRefundClaimed[auctionId][nullifierHash]) {
             revert ShieldedRefundAlreadyClaimed(auctionId, nullifierHash);
@@ -925,12 +957,45 @@ contract FhenixFairMarket is
         );
     }
 
+    function getAuctionDependencySnapshot(uint256 auctionId)
+        external
+        view
+        auctionExists(auctionId)
+        returns (
+            bool initialized,
+            address auctionCofheAdapter,
+            address auctionSettlementEngine,
+            address auctionSlashedPot,
+            address auctionShieldedEscrowVault,
+            address auctionShieldedIdentityRegistry
+        )
+    {
+        AuctionDependencySnapshot storage snapshot = _auctionDependencySnapshots[auctionId];
+        return (
+            snapshot.initialized,
+            snapshot.cofheAdapter,
+            snapshot.settlementEngine,
+            snapshot.slashedPot,
+            snapshot.shieldedEscrowVault,
+            snapshot.shieldedIdentityRegistry
+        );
+    }
+
     function previewDynamicTimeout() public view returns (uint256) {
         if (address(settlementEngine) == address(0)) {
             return _DEFAULT_DYNAMIC_TIMEOUT;
         }
 
         return settlementEngine.computeDynamicTimeout(movingAverageBlockDelta);
+    }
+
+    function _previewDynamicTimeoutForAuction(uint256 auctionId) internal view returns (uint256) {
+        ISettlementEngine auctionSettlementEngine = _auctionSettlementEngine(auctionId);
+        if (address(auctionSettlementEngine) == address(0)) {
+            return _DEFAULT_DYNAMIC_TIMEOUT;
+        }
+
+        return auctionSettlementEngine.computeDynamicTimeout(movingAverageBlockDelta);
     }
 
     function previewFinalizeReward(uint256 auctionId) public view auctionExists(auctionId) returns (uint256) {
@@ -949,11 +1014,12 @@ contract FhenixFairMarket is
         returns (uint256 escrowRefund, uint256 compensation)
     {
         Auction storage auction = _auctions[auctionId];
+        ISlashedPot auctionSlashedPot = _auctionSlashedPot(auctionId);
         uint256 escrowContribution = escrowBalances[auctionId][claimant];
 
         if (auction.state == AuctionState.FINALIZED) {
             if (claimant == auction.winner) {
-                escrowRefund = _computeWinningRefund(escrowContribution, auction.winningAmount);
+                escrowRefund = _computeWinningRefund(auctionId, escrowContribution, auction.winningAmount);
             } else {
                 escrowRefund = escrowContribution;
             }
@@ -963,8 +1029,8 @@ contract FhenixFairMarket is
 
         if (auction.state == AuctionState.CANCELLED || auction.state == AuctionState.VOIDED) {
             escrowRefund = escrowContribution;
-            if (escrowContribution != 0 && auction.slashAmount != 0 && address(slashedPot) != address(0)) {
-                compensation = slashedPot.previewClaim(auctionId, escrowContribution);
+            if (escrowContribution != 0 && auction.slashAmount != 0 && address(auctionSlashedPot) != address(0)) {
+                compensation = auctionSlashedPot.previewClaim(auctionId, escrowContribution);
             }
 
             return (escrowRefund, compensation);
@@ -978,12 +1044,12 @@ contract FhenixFairMarket is
         uint256 finalizeReward = _finalizationRewards[auctionId];
 
         if (auction.state == AuctionState.FINALIZED) {
-            uint256 grossPayout = _computeSellerPayout(auction.sellerDeposit, auction.winningAmount);
+            uint256 grossPayout = _computeSellerPayout(auctionId, auction.sellerDeposit, auction.winningAmount);
             return finalizeReward >= grossPayout ? 0 : grossPayout - finalizeReward;
         }
 
         if (auction.state == AuctionState.CANCELLED) {
-            return _computeSellerCancellationPayout(auction.sellerDeposit, auction.slashAmount);
+            return _computeSellerCancellationPayout(auctionId, auction.sellerDeposit, auction.slashAmount);
         }
 
         if (auction.state == AuctionState.VOIDED) {
@@ -1012,11 +1078,13 @@ contract FhenixFairMarket is
     ) internal returns (bool) {
         Auction storage auction = _auctions[auctionId];
         PendingResolutionRequest storage request = _resolutionRequests[auctionId];
+        ISettlementEngine auctionSettlementEngine = _auctionSettlementEngine(auctionId);
+        ICofheAdapter auctionAdapter = _auctionCofheAdapter(auctionId);
         if (!request.exists) {
             revert MissingResolutionRequest(auctionId);
         }
 
-        if (address(settlementEngine) == address(0)) {
+        if (address(auctionSettlementEngine) == address(0)) {
             revert InvalidAVSProof(auctionId, request.requestId);
         }
 
@@ -1034,7 +1102,7 @@ contract FhenixFairMarket is
             if (_encryptedBids[auctionId][winner] == bytes32(0)) {
                 revert MissingEncryptedBid(auctionId, winner);
             }
-            if (!cofheAdapter.lte(winnerCiphertext, escrowBalances[auctionId][winner])) {
+            if (!auctionAdapter.lte(winnerCiphertext, escrowBalances[auctionId][winner])) {
                 revert BidExceedsEscrow(auctionId, winner);
             }
             if (winningAmount > escrowBalances[auctionId][winner]) {
@@ -1043,7 +1111,7 @@ contract FhenixFairMarket is
         }
 
         if (
-            !settlementEngine.verifyResolutionProof(
+            !auctionSettlementEngine.verifyResolutionProof(
                 address(this),
                 auctionId,
                 request.requestId,
@@ -1078,17 +1146,20 @@ contract FhenixFairMarket is
     ) internal returns (bool) {
         Auction storage auction = _auctions[auctionId];
         PendingResolutionRequest storage request = _resolutionRequests[auctionId];
+        ISettlementEngine auctionSettlementEngine = _auctionSettlementEngine(auctionId);
+        IShieldedEscrowVault auctionVault = _auctionShieldedEscrowVault(auctionId);
+        IShieldedIdentityRegistry auctionRegistry = _auctionShieldedIdentityRegistry(auctionId);
         if (!request.exists) {
             revert MissingResolutionRequest(auctionId);
         }
-        if (address(settlementEngine) == address(0)) {
+        if (address(auctionSettlementEngine) == address(0)) {
             revert InvalidAVSProof(auctionId, request.requestId);
         }
         bytes32 winnerCommitmentHash =
             _validateShieldedResolutionBid(auctionId, winnerIdentityHash, winnerCiphertext, winningAmount, auction.startingPrice);
 
         if (
-            !settlementEngine.verifyShieldedResolutionProof(
+            !auctionSettlementEngine.verifyShieldedResolutionProof(
                 address(this),
                 auctionId,
                 request.requestId,
@@ -1110,12 +1181,11 @@ contract FhenixFairMarket is
         _transitionState(auctionId, AuctionState.FINALIZED);
         _observeNetwork();
 
-        uint256 remainingRefund =
-            shieldedEscrowVault.settleWinningCommitment(auctionId, winnerCommitmentHash, winningAmount);
+        uint256 remainingRefund = auctionVault.settleWinningCommitment(auctionId, winnerCommitmentHash, winningAmount);
         (remainingRefund);
 
         _openShieldedRefundPath(auctionId);
-        shieldedIdentityRegistry.markWinningIdentity(auctionId, winnerIdentityHash);
+        auctionRegistry.markWinningIdentity(auctionId, winnerIdentityHash);
         emit ResolutionRecorded(auctionId, address(0), winnerCiphertext);
         return true;
     }
@@ -1144,12 +1214,13 @@ contract FhenixFairMarket is
         if (storedBid != winnerCiphertext) {
             revert UnexpectedShieldedWinningCiphertext(auctionId, storedBid, winnerCiphertext);
         }
-        if (address(shieldedEscrowVault).code.length < 1) {
+        IShieldedEscrowVault auctionVault = _auctionShieldedEscrowVault(auctionId);
+        if (address(auctionVault).code.length < 1) {
             revert ShieldedEscrowVaultNotConfigured();
         }
 
         (uint256 commitmentAuctionId, bool refundUnlocked, bool claimed) =
-            shieldedEscrowVault.commitmentState(winnerCommitmentHash);
+            auctionVault.commitmentState(winnerCommitmentHash);
         (refundUnlocked);
         if (commitmentAuctionId != auctionId || claimed) {
             revert MissingShieldedEncryptedBid(auctionId, winnerCommitmentHash);
@@ -1160,26 +1231,28 @@ contract FhenixFairMarket is
         if (identityHash == bytes32(0)) {
             revert InvalidIdentityHash();
         }
-        if (address(shieldedIdentityRegistry).code.length < 1) {
+        IShieldedIdentityRegistry auctionRegistry = _auctionShieldedIdentityRegistry(auctionId);
+        if (address(auctionRegistry).code.length < 1) {
             revert ShieldedIdentityRegistryNotConfigured();
         }
 
-        commitmentHash = shieldedIdentityRegistry.commitmentForIdentity(auctionId, identityHash);
+        commitmentHash = auctionRegistry.commitmentForIdentity(auctionId, identityHash);
         if (commitmentHash == bytes32(0)) {
             revert MissingShieldedEncryptedBid(auctionId, identityHash);
         }
     }
 
     function _openShieldedRefundPath(uint256 auctionId) internal {
+        IShieldedEscrowVault auctionVault = _auctionShieldedEscrowVault(auctionId);
         if (shieldedRefundsUnlocked[auctionId]) {
             return;
         }
-        if (address(shieldedEscrowVault).code.length < 1) {
+        if (address(auctionVault).code.length < 1) {
             return;
         }
 
         shieldedRefundsUnlocked[auctionId] = true;
-        shieldedEscrowVault.unlockRefunds(auctionId);
+        auctionVault.unlockRefunds(auctionId);
         emit ShieldedRefundPathOpened(auctionId);
     }
 
@@ -1193,7 +1266,8 @@ contract FhenixFairMarket is
         view
         returns (ISettlementEngine.ResolutionRequest memory)
     {
-        if (address(settlementEngine) == address(0)) {
+        ISettlementEngine auctionSettlementEngine = _auctionSettlementEngine(auctionId);
+        if (address(auctionSettlementEngine) == address(0)) {
             bytes32 requestId = keccak256(
                 abi.encode(address(this), block.chainid, auctionId, auction.bidCount, auction.endTime, finalizeNonce, raceSalt)
             );
@@ -1205,7 +1279,7 @@ contract FhenixFairMarket is
                 });
         }
 
-        return settlementEngine.prepareResolutionRequest(
+        return auctionSettlementEngine.prepareResolutionRequest(
             address(this),
             auctionId,
             auction.bidCount,
@@ -1213,6 +1287,57 @@ contract FhenixFairMarket is
             finalizeNonce,
             raceSalt
         );
+    }
+
+    function _snapshotAuctionDependencies(uint256 auctionId) internal {
+        _auctionDependencySnapshots[auctionId] = AuctionDependencySnapshot({
+            initialized: true,
+            cofheAdapter: address(cofheAdapter),
+            settlementEngine: address(settlementEngine),
+            slashedPot: address(slashedPot),
+            shieldedEscrowVault: address(shieldedEscrowVault),
+            shieldedIdentityRegistry: address(shieldedIdentityRegistry)
+        });
+
+        emit AuctionDependencySnapshotted(
+            auctionId,
+            address(cofheAdapter),
+            address(settlementEngine),
+            address(slashedPot),
+            address(shieldedEscrowVault),
+            address(shieldedIdentityRegistry)
+        );
+    }
+
+    function _auctionCofheAdapter(uint256 auctionId) internal view returns (ICofheAdapter) {
+        AuctionDependencySnapshot storage snapshot = _auctionDependencySnapshots[auctionId];
+        return ICofheAdapter(snapshot.initialized ? snapshot.cofheAdapter : address(cofheAdapter));
+    }
+
+    function _auctionSettlementEngine(uint256 auctionId) internal view returns (ISettlementEngine) {
+        AuctionDependencySnapshot storage snapshot = _auctionDependencySnapshots[auctionId];
+        return ISettlementEngine(snapshot.initialized ? snapshot.settlementEngine : address(settlementEngine));
+    }
+
+    function _auctionSlashedPot(uint256 auctionId) internal view returns (ISlashedPot) {
+        AuctionDependencySnapshot storage snapshot = _auctionDependencySnapshots[auctionId];
+        return ISlashedPot(snapshot.initialized ? snapshot.slashedPot : address(slashedPot));
+    }
+
+    function _auctionShieldedEscrowVault(uint256 auctionId) internal view returns (IShieldedEscrowVault) {
+        AuctionDependencySnapshot storage snapshot = _auctionDependencySnapshots[auctionId];
+        return
+            IShieldedEscrowVault(
+                snapshot.initialized ? snapshot.shieldedEscrowVault : address(shieldedEscrowVault)
+            );
+    }
+
+    function _auctionShieldedIdentityRegistry(uint256 auctionId) internal view returns (IShieldedIdentityRegistry) {
+        AuctionDependencySnapshot storage snapshot = _auctionDependencySnapshots[auctionId];
+        return
+            IShieldedIdentityRegistry(
+                snapshot.initialized ? snapshot.shieldedIdentityRegistry : address(shieldedIdentityRegistry)
+            );
     }
 
     function _observeNetwork() internal {
@@ -1241,54 +1366,60 @@ contract FhenixFairMarket is
     }
 
     function _registerSlash(uint256 auctionId, uint256 totalEscrow, uint256 slashAmount) internal {
+        IShieldedEscrowVault auctionVault = _auctionShieldedEscrowVault(auctionId);
+        ISlashedPot auctionSlashedPot = _auctionSlashedPot(auctionId);
         if (slashAmount < 1) {
             return;
         }
         uint256 publicSlashAllocation = slashAmount;
-        if (address(shieldedEscrowVault).code.length > 0) {
-            publicSlashAllocation = shieldedEscrowVault.allocateSlash{value: slashAmount}(auctionId, totalEscrow);
+        if (address(auctionVault).code.length > 0) {
+            publicSlashAllocation = auctionVault.allocateSlash{value: slashAmount}(auctionId, totalEscrow);
         }
         if (publicSlashAllocation < 1) {
             return;
         }
-        if (address(slashedPot).code.length < 1) {
+        if (address(auctionSlashedPot).code.length < 1) {
             revert SlashedPotNotConfigured();
         }
 
         // slither-disable-next-line arbitrary-send-eth
-        slashedPot.registerSlash{value: publicSlashAllocation}(auctionId, totalEscrow);
+        auctionSlashedPot.registerSlash{value: publicSlashAllocation}(auctionId, totalEscrow);
     }
 
-    function _computeWinningRefund(uint256 escrowContribution, uint256 winningAmount) internal view returns (uint256) {
-        if (address(settlementEngine) == address(0)) {
+    function _computeWinningRefund(uint256 auctionId, uint256 escrowContribution, uint256 winningAmount) internal view returns (uint256) {
+        ISettlementEngine auctionSettlementEngine = _auctionSettlementEngine(auctionId);
+        if (address(auctionSettlementEngine) == address(0)) {
             return winningAmount >= escrowContribution ? 0 : escrowContribution - winningAmount;
         }
 
-        return settlementEngine.computeWinningRefund(escrowContribution, winningAmount);
+        return auctionSettlementEngine.computeWinningRefund(escrowContribution, winningAmount);
     }
 
-    function _computeSellerPayout(uint256 sellerDeposit, uint256 winningAmount) internal view returns (uint256) {
-        if (address(settlementEngine) == address(0)) {
+    function _computeSellerPayout(uint256 auctionId, uint256 sellerDeposit, uint256 winningAmount) internal view returns (uint256) {
+        ISettlementEngine auctionSettlementEngine = _auctionSettlementEngine(auctionId);
+        if (address(auctionSettlementEngine) == address(0)) {
             return sellerDeposit + winningAmount;
         }
 
-        return settlementEngine.computeSellerPayout(sellerDeposit, winningAmount);
+        return auctionSettlementEngine.computeSellerPayout(sellerDeposit, winningAmount);
     }
 
-    function _computeSellerCancellationPayout(uint256 sellerDeposit, uint256 slashAmount) internal view returns (uint256) {
-        if (address(settlementEngine) == address(0)) {
+    function _computeSellerCancellationPayout(uint256 auctionId, uint256 sellerDeposit, uint256 slashAmount) internal view returns (uint256) {
+        ISettlementEngine auctionSettlementEngine = _auctionSettlementEngine(auctionId);
+        if (address(auctionSettlementEngine) == address(0)) {
             return slashAmount >= sellerDeposit ? 0 : sellerDeposit - slashAmount;
         }
 
-        return settlementEngine.computeSellerCancellationPayout(sellerDeposit, slashAmount);
+        return auctionSettlementEngine.computeSellerCancellationPayout(sellerDeposit, slashAmount);
     }
 
     function _computeCancellationSlash(uint256 auctionId, Auction storage auction) internal view returns (uint256) {
+        ISettlementEngine auctionSettlementEngine = _auctionSettlementEngine(auctionId);
         uint256 totalEscrowIncludingShielded = _totalEscrowIncludingShielded(auctionId, auction);
         if (totalEscrowIncludingShielded == 0) {
             return 0;
         }
-        if (address(settlementEngine) == address(0)) {
+        if (address(auctionSettlementEngine) == address(0)) {
             return auction.sellerDeposit / 2;
         }
 
@@ -1296,7 +1427,7 @@ contract FhenixFairMarket is
         uint256 duration = uint256(auction.endTime) - auction.createdAt;
 
         return
-            settlementEngine.computeCancellationSlash(
+            auctionSettlementEngine.computeCancellationSlash(
                 auction.sellerDeposit,
                 elapsed,
                 duration,
@@ -1309,11 +1440,12 @@ contract FhenixFairMarket is
     }
 
     function _shieldedEscrowTotal(uint256 auctionId) internal view returns (uint256) {
-        if (address(shieldedEscrowVault).code.length < 1) {
+        IShieldedEscrowVault auctionVault = _auctionShieldedEscrowVault(auctionId);
+        if (address(auctionVault).code.length < 1) {
             return 0;
         }
 
-        return shieldedEscrowVault.totalEscrowForAuction(auctionId);
+        return auctionVault.totalEscrowForAuction(auctionId);
     }
 
     function _computeFinalizeReward(uint256 sellerDeposit) internal pure returns (uint256) {

--- a/packages/contracts/contracts/mocks/MockRevertingCofheAdapter.sol
+++ b/packages/contracts/contracts/mocks/MockRevertingCofheAdapter.sol
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+import "../interfaces/ICofheAdapter.sol";
+
+contract MockRevertingCofheAdapter is ICofheAdapter {
+    error PrototypeComparisonDisabled();
+
+    function lte(bytes32, uint256) external pure override returns (bool) {
+        revert PrototypeComparisonDisabled();
+    }
+
+    function gt(bytes32, uint256) external pure override returns (bool) {
+        revert PrototypeComparisonDisabled();
+    }
+
+    function asEuint32(uint32 value) external pure override returns (bytes32) {
+        return bytes32(uint256(value));
+    }
+
+    function asEuint96(uint96 value) external pure override returns (bytes32) {
+        return bytes32(uint256(value));
+    }
+
+    function asEbool(bool value) external pure override returns (bytes32) {
+        return value ? bytes32(uint256(1)) : bytes32(0);
+    }
+
+    function select(bytes32 conditionCiphertext, bytes32 whenTrueCiphertext, bytes32 whenFalseCiphertext)
+        external
+        pure
+        override
+        returns (bytes32)
+    {
+        return conditionCiphertext == bytes32(0) ? whenFalseCiphertext : whenTrueCiphertext;
+    }
+
+    function verifyEncryptedBidCoverage(bytes32, uint256) external pure override returns (bool) {
+        revert PrototypeComparisonDisabled();
+    }
+
+    function ciphertextKind(bytes32) external pure override returns (uint8) {
+        return 0;
+    }
+
+    function seal(bytes32 ciphertext, address) external pure override returns (bytes32) {
+        return ciphertext;
+    }
+}

--- a/packages/contracts/hardhat.config.ts
+++ b/packages/contracts/hardhat.config.ts
@@ -23,7 +23,8 @@ const config: HardhatUserConfig = {
   },
   networks: {
     hardhat: {
-      chainId: 31337
+      chainId: 31337,
+      blockGasLimit: 60_000_000
     },
     localhost: {
       url: process.env.RPC_URL || "http://127.0.0.1:8545",

--- a/packages/contracts/hardhat.config.ts
+++ b/packages/contracts/hardhat.config.ts
@@ -23,8 +23,7 @@ const config: HardhatUserConfig = {
   },
   networks: {
     hardhat: {
-      chainId: 31337,
-      blockGasLimit: 60_000_000
+      chainId: 31337
     },
     localhost: {
       url: process.env.RPC_URL || "http://127.0.0.1:8545",

--- a/packages/contracts/test/helpers/fixtures.ts
+++ b/packages/contracts/test/helpers/fixtures.ts
@@ -1,5 +1,7 @@
 import { ethers } from "hardhat";
 
+const COVERAGE_SAFE_GAS_LIMIT = 40_000_000;
+
 export async function deployPhase2Fixture() {
   const [owner, seller, bidder, bidderTwo, outsider, avsOperatorOne, avsOperatorTwo, avsOperatorThree] =
     await ethers.getSigners();
@@ -25,7 +27,7 @@ export async function deployPhase2Fixture() {
   await avs.waitForDeployment();
 
   const implementationFactory = await ethers.getContractFactory("FhenixFairMarket");
-  const implementation = await implementationFactory.deploy();
+  const implementation = await implementationFactory.deploy({ gasLimit: COVERAGE_SAFE_GAS_LIMIT });
   await implementation.waitForDeployment();
 
   const proxyFactory = await ethers.getContractFactory("FhenixFairMarketProxy");
@@ -35,7 +37,9 @@ export async function deployPhase2Fixture() {
     await slashedPot.getAddress()
   ]);
 
-  const proxy = await proxyFactory.deploy(await implementation.getAddress(), initData);
+  const proxy = await proxyFactory.deploy(await implementation.getAddress(), initData, {
+    gasLimit: COVERAGE_SAFE_GAS_LIMIT
+  });
   await proxy.waitForDeployment();
 
   const market = implementationFactory.attach(await proxy.getAddress());

--- a/packages/contracts/test/helpers/fixtures.ts
+++ b/packages/contracts/test/helpers/fixtures.ts
@@ -1,6 +1,13 @@
-import { ethers } from "hardhat";
+import { ethers, network } from "hardhat";
 
+const COVERAGE_BLOCK_GAS_LIMIT = 0x1fffffffffffff;
 const COVERAGE_SAFE_GAS_LIMIT = 40_000_000;
+
+export function getCoverageSafeDeployOverrides() {
+  return network.name === "hardhat" && network.config.blockGasLimit === COVERAGE_BLOCK_GAS_LIMIT
+    ? { gasLimit: COVERAGE_SAFE_GAS_LIMIT }
+    : {};
+}
 
 export async function deployPhase2Fixture() {
   const [owner, seller, bidder, bidderTwo, outsider, avsOperatorOne, avsOperatorTwo, avsOperatorThree] =
@@ -27,7 +34,7 @@ export async function deployPhase2Fixture() {
   await avs.waitForDeployment();
 
   const implementationFactory = await ethers.getContractFactory("FhenixFairMarket");
-  const implementation = await implementationFactory.deploy({ gasLimit: COVERAGE_SAFE_GAS_LIMIT });
+  const implementation = await implementationFactory.deploy(getCoverageSafeDeployOverrides());
   await implementation.waitForDeployment();
 
   const proxyFactory = await ethers.getContractFactory("FhenixFairMarketProxy");
@@ -37,9 +44,11 @@ export async function deployPhase2Fixture() {
     await slashedPot.getAddress()
   ]);
 
-  const proxy = await proxyFactory.deploy(await implementation.getAddress(), initData, {
-    gasLimit: COVERAGE_SAFE_GAS_LIMIT
-  });
+  const proxy = await proxyFactory.deploy(
+    await implementation.getAddress(),
+    initData,
+    getCoverageSafeDeployOverrides()
+  );
   await proxy.waitForDeployment();
 
   const market = implementationFactory.attach(await proxy.getAddress());

--- a/packages/contracts/test/unit/AsyncResolution.test.ts
+++ b/packages/contracts/test/unit/AsyncResolution.test.ts
@@ -5,6 +5,8 @@ import { ethers } from "hardhat";
 import { createPhase2AuctionFixture } from "../helpers/fixtures";
 import { buildPhase3ResolutionProof, collectEncryptedBids } from "../helpers/phase3";
 
+const COVERAGE_SAFE_GAS_LIMIT = 40_000_000;
+
 describe("Phase 2 async resolution and settlement", function () {
   it("rejects encrypted bids that exceed the caller's escrow and stores valid bid handles", async function () {
     const { adapter, bidder, market } = await loadFixture(createPhase2AuctionFixture);
@@ -212,7 +214,7 @@ describe("Phase 2 async resolution and settlement", function () {
     const { proof } = await buildPhase3ResolutionProof(market, avs, 1n, encryptedBids, [avsOperatorOne, avsOperatorTwo]);
 
     const implementationFactory = await ethers.getContractFactory("FhenixFairMarket");
-    const implementation = await implementationFactory.deploy();
+    const implementation = await implementationFactory.deploy({ gasLimit: COVERAGE_SAFE_GAS_LIMIT });
     await implementation.waitForDeployment();
 
     const proxyFactory = await ethers.getContractFactory("FhenixFairMarketProxy");
@@ -221,7 +223,9 @@ describe("Phase 2 async resolution and settlement", function () {
       owner.address,
       await slashedPot.getAddress()
     ]);
-    const proxy = await proxyFactory.deploy(await implementation.getAddress(), initData);
+    const proxy = await proxyFactory.deploy(await implementation.getAddress(), initData, {
+      gasLimit: COVERAGE_SAFE_GAS_LIMIT
+    });
     await proxy.waitForDeployment();
 
     const secondMarket = implementationFactory.attach(await proxy.getAddress());

--- a/packages/contracts/test/unit/AsyncResolution.test.ts
+++ b/packages/contracts/test/unit/AsyncResolution.test.ts
@@ -2,10 +2,8 @@ import { loadFixture, time } from "@nomicfoundation/hardhat-network-helpers";
 import { expect } from "chai";
 import { ethers } from "hardhat";
 
-import { createPhase2AuctionFixture } from "../helpers/fixtures";
+import { createPhase2AuctionFixture, getCoverageSafeDeployOverrides } from "../helpers/fixtures";
 import { buildPhase3ResolutionProof, collectEncryptedBids } from "../helpers/phase3";
-
-const COVERAGE_SAFE_GAS_LIMIT = 40_000_000;
 
 describe("Phase 2 async resolution and settlement", function () {
   it("rejects encrypted bids that exceed the caller's escrow and stores valid bid handles", async function () {
@@ -214,7 +212,7 @@ describe("Phase 2 async resolution and settlement", function () {
     const { proof } = await buildPhase3ResolutionProof(market, avs, 1n, encryptedBids, [avsOperatorOne, avsOperatorTwo]);
 
     const implementationFactory = await ethers.getContractFactory("FhenixFairMarket");
-    const implementation = await implementationFactory.deploy({ gasLimit: COVERAGE_SAFE_GAS_LIMIT });
+    const implementation = await implementationFactory.deploy(getCoverageSafeDeployOverrides());
     await implementation.waitForDeployment();
 
     const proxyFactory = await ethers.getContractFactory("FhenixFairMarketProxy");
@@ -223,9 +221,11 @@ describe("Phase 2 async resolution and settlement", function () {
       owner.address,
       await slashedPot.getAddress()
     ]);
-    const proxy = await proxyFactory.deploy(await implementation.getAddress(), initData, {
-      gasLimit: COVERAGE_SAFE_GAS_LIMIT
-    });
+    const proxy = await proxyFactory.deploy(
+      await implementation.getAddress(),
+      initData,
+      getCoverageSafeDeployOverrides()
+    );
     await proxy.waitForDeployment();
 
     const secondMarket = implementationFactory.attach(await proxy.getAddress());

--- a/packages/contracts/test/unit/AsyncResolution.test.ts
+++ b/packages/contracts/test/unit/AsyncResolution.test.ts
@@ -29,7 +29,7 @@ describe("Phase 2 async resolution and settlement", function () {
   });
 
   it("settles finalized auctions through pull-based refunds, seller proceeds, and deferred NFT claims", async function () {
-    const { adapter, avs, avsOperatorOne, avsOperatorTwo, bidder, bidderTwo, market, nft, owner, seller } =
+    const { adapter, avs, avsOperatorOne, avsOperatorTwo, bidder, bidderTwo, market, nft, outsider, seller } =
       await loadFixture(createPhase2AuctionFixture);
 
     await market.connect(bidder).lockEscrow(1n, { value: 600n });
@@ -48,7 +48,7 @@ describe("Phase 2 async resolution and settlement", function () {
     const { proof } = await buildPhase3ResolutionProof(market, avs, 1n, encryptedBids, [avsOperatorOne, avsOperatorTwo]);
 
     await expect(
-      market.connect(owner)["submitResolution(uint256,address,bytes32,uint256,bytes)"](
+      market.connect(outsider)["submitResolution(uint256,address,bytes32,uint256,bytes)"](
         1n,
         bidder.address,
         winnerBid,
@@ -58,6 +58,16 @@ describe("Phase 2 async resolution and settlement", function () {
     )
       .to.emit(market, "ResolutionRecorded")
       .withArgs(1n, bidder.address, winnerBid);
+
+    await expect(
+      market.connect(seller)["submitResolution(uint256,address,bytes32,uint256,bytes)"](
+        1n,
+        bidder.address,
+        winnerBid,
+        450n,
+        proof
+      )
+    ).to.be.revertedWithCustomError(market, "UnexpectedAuctionState");
 
     const winnerPreview = await market.previewRefund(1n, bidder.address);
     const runnerUpPreview = await market.previewRefund(1n, bidderTwo.address);
@@ -151,7 +161,7 @@ describe("Phase 2 async resolution and settlement", function () {
   });
 
   it("keeps the auction in resolving and slashes attesters when the submitted resolution payload is tampered with", async function () {
-    const { adapter, avs, avsOperatorOne, avsOperatorTwo, bidder, bidderTwo, market, owner } =
+    const { adapter, avs, avsOperatorOne, avsOperatorTwo, bidder, bidderTwo, market, outsider } =
       await loadFixture(createPhase2AuctionFixture);
 
     await market.connect(bidder).lockEscrow(1n, { value: 600n });
@@ -170,7 +180,7 @@ describe("Phase 2 async resolution and settlement", function () {
     ]);
 
     await expect(
-      market.connect(owner)["submitResolution(uint256,address,bytes32,uint256,bytes)"](
+      market.connect(outsider)["submitResolution(uint256,address,bytes32,uint256,bytes)"](
         1n,
         bidder.address,
         await adapter.asEuint32(450),

--- a/packages/contracts/test/unit/EscrowLogic.test.ts
+++ b/packages/contracts/test/unit/EscrowLogic.test.ts
@@ -22,22 +22,14 @@ describe("FhenixFairMarket Phase 1", function () {
     expect(await market.contractVersion()).to.equal("phase4-privacy4");
   });
 
-  it("rejects invalid initialization parameters on a fresh implementation", async function () {
-    const { adapter, owner } = await loadFixture(deployFixture);
-
+  it("disables direct initialization on the implementation contract", async function () {
     const implementationFactory = await ethers.getContractFactory("FhenixFairMarket");
+    const rawImplementation = await implementationFactory.deploy();
+    await rawImplementation.waitForDeployment();
 
-    const rawImplementationA = await implementationFactory.deploy();
-    await rawImplementationA.waitForDeployment();
     await expect(
-      rawImplementationA.initialize(ethers.ZeroAddress, owner.address, ethers.ZeroAddress)
-    ).to.be.revertedWithCustomError(rawImplementationA, "ZeroAddress");
-
-    const rawImplementationB = await implementationFactory.deploy();
-    await rawImplementationB.waitForDeployment();
-    await expect(
-      rawImplementationB.initialize(await adapter.getAddress(), ethers.ZeroAddress, ethers.ZeroAddress)
-    ).to.be.revertedWithCustomError(rawImplementationB, "ZeroAddress");
+      rawImplementation.initialize(ethers.ZeroAddress, ethers.ZeroAddress, ethers.ZeroAddress)
+    ).to.be.revertedWithCustomError(rawImplementation, "InvalidInitialization");
   });
 
   it("allows the owner to rotate the CoFHE adapter for future bid formats", async function () {
@@ -56,6 +48,102 @@ describe("FhenixFairMarket Phase 1", function () {
       .withArgs(anyValue, await nextAdapter.getAddress());
 
     expect(await market.cofheAdapter()).to.equal(await nextAdapter.getAddress());
+  });
+
+  it("snapshots dependencies at auction creation and preserves the original adapter after rotation", async function () {
+    const { adapter, bidder, market, nft, owner, seller, settlementEngine, slashedPot } =
+      await loadFixture(deployFixture);
+
+    await nft.connect(seller).mint(seller.address);
+    await nft.connect(seller).approve(await market.getAddress(), 1n);
+
+    await expect(
+      market
+        .connect(seller)
+        ["createAuction(address,uint256,uint256,uint256,uint256,bool)"](
+          await nft.getAddress(),
+          1n,
+          24 * 60 * 60,
+          400n,
+          ethers.parseEther("1"),
+          true,
+          {
+            value: ethers.parseEther("1")
+          }
+        )
+    )
+      .to.emit(market, "AuctionDependencySnapshotted")
+      .withArgs(
+        1n,
+        await adapter.getAddress(),
+        await settlementEngine.getAddress(),
+        await slashedPot.getAddress(),
+        ethers.ZeroAddress,
+        ethers.ZeroAddress
+      );
+
+    const [initialized, auctionAdapter, auctionSettlementEngine, auctionSlashedPot, auctionVault, auctionRegistry] =
+      await market.getAuctionDependencySnapshot(1n);
+    expect(initialized).to.equal(true);
+    expect(auctionAdapter).to.equal(await adapter.getAddress());
+    expect(auctionSettlementEngine).to.equal(await settlementEngine.getAddress());
+    expect(auctionSlashedPot).to.equal(await slashedPot.getAddress());
+    expect(auctionVault).to.equal(ethers.ZeroAddress);
+    expect(auctionRegistry).to.equal(ethers.ZeroAddress);
+
+    const revertingAdapterFactory = await ethers.getContractFactory("MockRevertingCofheAdapter");
+    const nextAdapter = await revertingAdapterFactory.deploy();
+    await nextAdapter.waitForDeployment();
+
+    await market.connect(owner).setCofheAdapter(await nextAdapter.getAddress());
+    expect(await market.cofheAdapter()).to.equal(await nextAdapter.getAddress());
+
+    await market.connect(bidder).lockEscrow(1n, { value: 600n });
+    const originalBidHandle = await adapter.asEuint96(450n);
+
+    await expect(market.connect(bidder).placeBid(1n, originalBidHandle))
+      .to.emit(market, "BidPlaced")
+      .withArgs(1n, bidder.address, originalBidHandle);
+  });
+
+  it("routes cancellation slash to the auction's snapshotted slashed pot after rotation", async function () {
+    const { bidder, market, nft, owner, seller, settlementEngine, slashedPot } = await loadFixture(deployFixture);
+
+    await nft.connect(seller).mint(seller.address);
+    await nft.connect(seller).approve(await market.getAddress(), 1n);
+    await market
+      .connect(seller)
+      ["createAuction(address,uint256,uint256,uint256,bool)"](
+        await nft.getAddress(),
+        1n,
+        24 * 60 * 60,
+        ethers.parseEther("1"),
+        true,
+        {
+          value: ethers.parseEther("1")
+        }
+      );
+
+    const [, , , snapshottedSlashedPot] = await market.getAuctionDependencySnapshot(1n);
+    expect(snapshottedSlashedPot).to.equal(await slashedPot.getAddress());
+
+    const slashedPotFactory = await ethers.getContractFactory("SlashedPot");
+    const rotatedSlashedPot = await slashedPotFactory.deploy(owner.address, await settlementEngine.getAddress());
+    await rotatedSlashedPot.waitForDeployment();
+    await rotatedSlashedPot.connect(owner).setMarket(await market.getAddress());
+
+    await market.connect(owner).setSlashedPot(await rotatedSlashedPot.getAddress());
+    await market.connect(bidder).lockEscrow(1n, { value: ethers.parseEther("0.4") });
+
+    const originalPotBalanceBefore = await ethers.provider.getBalance(await slashedPot.getAddress());
+
+    await market.connect(seller).cancelAuction(1n);
+
+    const originalPotBalanceAfter = await ethers.provider.getBalance(await slashedPot.getAddress());
+    const rotatedPotBalanceAfter = await ethers.provider.getBalance(await rotatedSlashedPot.getAddress());
+
+    expect(originalPotBalanceAfter).to.be.gt(originalPotBalanceBefore);
+    expect(rotatedPotBalanceAfter).to.equal(0n);
   });
 
   it("creates an auction and transfers the NFT into escrow", async function () {

--- a/packages/contracts/test/unit/EscrowLogic.test.ts
+++ b/packages/contracts/test/unit/EscrowLogic.test.ts
@@ -6,6 +6,8 @@ import { ethers } from "hardhat";
 import { createPhase2AuctionFixture, deployPhase2Fixture } from "../helpers/fixtures";
 import { buildPhase3ResolutionProof, collectEncryptedBids } from "../helpers/phase3";
 
+const COVERAGE_SAFE_GAS_LIMIT = 40_000_000;
+
 describe("FhenixFairMarket Phase 1", function () {
   async function deployFixture() {
     return deployPhase2Fixture();
@@ -24,7 +26,7 @@ describe("FhenixFairMarket Phase 1", function () {
 
   it("disables direct initialization on the implementation contract", async function () {
     const implementationFactory = await ethers.getContractFactory("FhenixFairMarket");
-    const rawImplementation = await implementationFactory.deploy();
+    const rawImplementation = await implementationFactory.deploy({ gasLimit: COVERAGE_SAFE_GAS_LIMIT });
     await rawImplementation.waitForDeployment();
 
     await expect(
@@ -641,7 +643,7 @@ describe("FhenixFairMarket Phase 1", function () {
     const { market, proxy, bidder } = await loadFixture(deployFixture);
 
     const v2Factory = await ethers.getContractFactory("MockFhenixFairMarketV2");
-    const v2Implementation = await v2Factory.deploy();
+    const v2Implementation = await v2Factory.deploy({ gasLimit: COVERAGE_SAFE_GAS_LIMIT });
     await v2Implementation.waitForDeployment();
 
     await expect(

--- a/packages/contracts/test/unit/EscrowLogic.test.ts
+++ b/packages/contracts/test/unit/EscrowLogic.test.ts
@@ -3,10 +3,8 @@ import { anyValue } from "@nomicfoundation/hardhat-chai-matchers/withArgs";
 import { expect } from "chai";
 import { ethers } from "hardhat";
 
-import { createPhase2AuctionFixture, deployPhase2Fixture } from "../helpers/fixtures";
+import { createPhase2AuctionFixture, deployPhase2Fixture, getCoverageSafeDeployOverrides } from "../helpers/fixtures";
 import { buildPhase3ResolutionProof, collectEncryptedBids } from "../helpers/phase3";
-
-const COVERAGE_SAFE_GAS_LIMIT = 40_000_000;
 
 describe("FhenixFairMarket Phase 1", function () {
   async function deployFixture() {
@@ -26,7 +24,7 @@ describe("FhenixFairMarket Phase 1", function () {
 
   it("disables direct initialization on the implementation contract", async function () {
     const implementationFactory = await ethers.getContractFactory("FhenixFairMarket");
-    const rawImplementation = await implementationFactory.deploy({ gasLimit: COVERAGE_SAFE_GAS_LIMIT });
+    const rawImplementation = await implementationFactory.deploy(getCoverageSafeDeployOverrides());
     await rawImplementation.waitForDeployment();
 
     await expect(
@@ -643,7 +641,7 @@ describe("FhenixFairMarket Phase 1", function () {
     const { market, proxy, bidder } = await loadFixture(deployFixture);
 
     const v2Factory = await ethers.getContractFactory("MockFhenixFairMarketV2");
-    const v2Implementation = await v2Factory.deploy({ gasLimit: COVERAGE_SAFE_GAS_LIMIT });
+    const v2Implementation = await v2Factory.deploy(getCoverageSafeDeployOverrides());
     await v2Implementation.waitForDeployment();
 
     await expect(

--- a/packages/contracts/test/unit/ShieldedBlindResolution.test.ts
+++ b/packages/contracts/test/unit/ShieldedBlindResolution.test.ts
@@ -2,12 +2,12 @@ import { loadFixture, time } from "@nomicfoundation/hardhat-network-helpers";
 import { expect } from "chai";
 import { ethers } from "hardhat";
 
-import { createPhase2AuctionFixture } from "../helpers/fixtures";
+import { deployPhase2Fixture } from "../helpers/fixtures";
 import { buildShieldedResolutionProof, collectAllEncryptedBids } from "../helpers/phase3";
 
 async function createShieldedBlindFixture() {
-  const context = await createPhase2AuctionFixture();
-  const { market, owner } = context;
+  const context = await deployPhase2Fixture();
+  const { market, nft, owner, seller } = context;
   const shieldedBidProver = ethers.Wallet.createRandom();
 
   const vaultFactory = await ethers.getContractFactory("ShieldedEscrowVault");
@@ -28,6 +28,21 @@ async function createShieldedBlindFixture() {
   await registry.connect(owner).setMarket(await market.getAddress());
   await market.connect(owner).setShieldedEscrowVault(await vault.getAddress());
   await market.connect(owner).setShieldedIdentityRegistry(await registry.getAddress());
+
+  await nft.connect(seller).mint(seller.address);
+  await nft.connect(seller).approve(await market.getAddress(), 1n);
+  await market
+    .connect(seller)
+    ["createAuction(address,uint256,uint256,uint256,bool)"](
+      await nft.getAddress(),
+      1n,
+      24 * 60 * 60,
+      ethers.parseEther("1"),
+      true,
+      {
+        value: ethers.parseEther("1")
+      }
+    );
 
   return {
     ...context,

--- a/packages/contracts/test/unit/ShieldedBlindResolution.test.ts
+++ b/packages/contracts/test/unit/ShieldedBlindResolution.test.ts
@@ -316,7 +316,7 @@ describe("Privacy Phase 2 blind resolution", function () {
       avsOperatorTwo
     ]);
 
-    await expect(market.connect(owner).submitShieldedResolution(1n, winnerNote.identityHash, winnerBid, 450n, proof))
+    await expect(market.connect(outsider).submitShieldedResolution(1n, winnerNote.identityHash, winnerBid, 450n, proof))
       .to.emit(market, "ResolutionRecorded")
       .withArgs(1n, ethers.ZeroAddress, winnerBid);
 

--- a/packages/contracts/test/unit/ShieldedEscrowVault.test.ts
+++ b/packages/contracts/test/unit/ShieldedEscrowVault.test.ts
@@ -3,7 +3,7 @@ import { expect } from "chai";
 import { ethers } from "hardhat";
 
 import { buildPhase3ResolutionProof, collectEncryptedBids } from "../helpers/phase3";
-import { createPhase2AuctionFixture } from "../helpers/fixtures";
+import { deployPhase2Fixture } from "../helpers/fixtures";
 
 function buildShieldedNote(label: string) {
   const identityHash = ethers.id(`${label}:identity`);
@@ -87,8 +87,8 @@ async function signVerifierCoverage(
 
 describe("ShieldedEscrowVault Privacy Phase 1", function () {
   async function createShieldedFixture() {
-    const context = await createPhase2AuctionFixture();
-    const { market, owner } = context;
+    const context = await deployPhase2Fixture();
+    const { market, nft, owner, seller } = context;
 
     const vaultFactory = await ethers.getContractFactory("ShieldedEscrowVault");
     const vault = await vaultFactory.deploy(owner.address);
@@ -103,6 +103,21 @@ describe("ShieldedEscrowVault Privacy Phase 1", function () {
     await registry.connect(owner).setMarket(await market.getAddress());
     await market.connect(owner).setShieldedEscrowVault(await vault.getAddress());
     await market.connect(owner).setShieldedIdentityRegistry(await registry.getAddress());
+
+    await nft.connect(seller).mint(seller.address);
+    await nft.connect(seller).approve(await market.getAddress(), 1n);
+    await market
+      .connect(seller)
+      ["createAuction(address,uint256,uint256,uint256,bool)"](
+        await nft.getAddress(),
+        1n,
+        24 * 60 * 60,
+        ethers.parseEther("1"),
+        true,
+        {
+          value: ethers.parseEther("1")
+        }
+      );
 
     return {
       ...context,

--- a/packages/contracts/test/unit/ZkShieldedBidVerifier.test.ts
+++ b/packages/contracts/test/unit/ZkShieldedBidVerifier.test.ts
@@ -2,7 +2,7 @@ import { loadFixture, time } from "@nomicfoundation/hardhat-network-helpers";
 import { expect } from "chai";
 import { ethers } from "hardhat";
 
-import { createPhase2AuctionFixture } from "../helpers/fixtures";
+import { deployPhase2Fixture } from "../helpers/fixtures";
 import { loadDemoProofBytes } from "../helpers/zkProof";
 
 function buildShieldedNote(label: string) {
@@ -23,8 +23,8 @@ function buildShieldedNote(label: string) {
 
 describe("ShieldedEscrowVault zk verifier integration", function () {
   async function createShieldedFixture() {
-    const context = await createPhase2AuctionFixture();
-    const { market, owner } = context;
+    const context = await deployPhase2Fixture();
+    const { market, nft, owner, seller } = context;
 
     const vaultFactory = await ethers.getContractFactory("ShieldedEscrowVault");
     const vault = await vaultFactory.deploy(owner.address);
@@ -39,6 +39,21 @@ describe("ShieldedEscrowVault zk verifier integration", function () {
     await registry.connect(owner).setMarket(await market.getAddress());
     await market.connect(owner).setShieldedEscrowVault(await vault.getAddress());
     await market.connect(owner).setShieldedIdentityRegistry(await registry.getAddress());
+
+    await nft.connect(seller).mint(seller.address);
+    await nft.connect(seller).approve(await market.getAddress(), 1n);
+    await market
+      .connect(seller)
+      ["createAuction(address,uint256,uint256,uint256,bool)"](
+        await nft.getAddress(),
+        1n,
+        24 * 60 * 60,
+        ethers.parseEther("1"),
+        true,
+        {
+          value: ethers.parseEther("1")
+        }
+      );
 
     return {
       ...context,

--- a/packages/keeper/runner.ts
+++ b/packages/keeper/runner.ts
@@ -330,9 +330,9 @@ async function startAvsSubmitter(
 
   if (canSubmitOnChain) {
     const provider = new JsonRpcProvider(config.rpcUrl);
-    const keeperWallet = createWalletOrUndefined(process.env.PRIVATE_KEY, provider);
-    if (keeperWallet) {
-      writer = new EthersResolutionWriter(new Contract(config.marketAddress, MARKET_ABI, keeperWallet));
+    const submitterWallet = createWalletOrUndefined(process.env.PRIVATE_KEY, provider);
+    if (submitterWallet) {
+      writer = new EthersResolutionWriter(new Contract(config.marketAddress, MARKET_ABI, submitterWallet));
       digestReader = new Contract(config.avsAddress, AVS_ABI, provider);
       operatorSigners = config.avsOperatorPrivateKeys
         .filter(isValidPrivateKey)
@@ -345,7 +345,7 @@ async function startAvsSubmitter(
         );
     }
   } else {
-    console.log("[keeper] avs-submitter will observe only until market, AVS, and operator keys are configured");
+    console.log("[keeper] avs-submitter will observe only until market, AVS, operator keys, and a relayer PRIVATE_KEY are configured");
   }
 
   setInterval(async () => {


### PR DESCRIPTION
## Summary

This PR hardens admin-sensitive dependency handling by snapshotting critical protocol dependencies at auction creation time instead of resolving them dynamically from mutable global addresses throughout the auction lifecycle.

It also disables direct initialization of the `FhenixFairMarket` implementation contract.

This means an auction keeps using the dependency set it was created with, even if the owner later rotates public dependency addresses for future auctions.

## What changed

- add `_disableInitializers()` to `FhenixFairMarket` implementation
- add per-auction dependency snapshot storage
- snapshot these dependencies at auction creation:
  - `cofheAdapter`
  - `settlementEngine`
  - `slashedPot`
  - `shieldedEscrowVault`
  - `shieldedIdentityRegistry`
- add `AuctionDependencySnapshotted` event for monitoring
- add `getAuctionDependencySnapshot(uint256)` view for inspection
- route auction lifecycle logic through snapshotted dependencies instead of mutable globals
- keep backward compatibility for pre-upgrade auctions by falling back to current globals when no snapshot exists
- add regression coverage proving:
  - direct implementation initialization is blocked
  - old auctions keep using their original adapter after global rotation
  - slash routing stays pinned to the original slashed pot after rotation
- update shielded test fixtures so shielded vault/registry are configured before auction creation, matching the new snapshot model

## Security impact

Before this PR:

- an owner could rotate live dependencies and affect already-created auctions
- auction execution could drift across adapter, settlement, slash, or shielded dependency changes
- implementation contract initialization was not explicitly disabled

After this PR:

- each auction uses a fixed dependency set captured at listing time
- public dependency rotation only affects future auctions
- implementation contract cannot be initialized directly
- dependency capture is visible through an event and getter for monitoring

## Acceptance mapping for Issue #7

Addresses:

- [ ] `#7.1` Put owner behind multisig
- [ ] `#7.2` Add timelock for critical dependency changes
- [ ] `#7.3` Prevent dependency changes during `ACTIVE` or `RESOLVING` auctions
- [x] `#7.4` Implement per-auction dependency snapshot at creation
- [x] `#7.5` Add `_disableInitializers()` in implementation contracts
- [x] `#7.6` Add administrative monitoring for rotation events

## Acceptance criteria status

- [x] Critical dependencies cannot change the behavior of already-created auctions
- [x] Auctions use a fixed snapshot even if public dependency addresses change
- [x] Implementation contract cannot be initialized directly

## Validation

- `hardhat compile`
- `hardhat test test/unit/EscrowLogic.test.ts`
- `hardhat test test/unit/AsyncResolution.test.ts test/unit/ShieldedBlindResolution.test.ts`
- `hardhat test test/unit/ShieldedEscrowVault.test.ts test/unit/ZkShieldedBidVerifier.test.ts`

## Notes

This PR intentionally takes the `#7.4` route instead of `#7.3`.

Rather than blocking all dependency rotation during active auctions, it freezes each auction onto its original dependency set. That gives stronger per-auction determinism while still allowing controlled global rotations for future listings.

Multisig ownership and timelock governance remain follow-up work.
