### PR TITLE
fix(security): wire live CoFHE bid flow and AVS-backed winner results

### DIFF
--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -13,10 +13,12 @@
     "test:e2e:headed": "playwright test --headed"
   },
   "dependencies": {
+    "@cofhe/sdk": "^0.5.2",
     "ethers": "^6.14.0",
     "next": "^15.0.0",
     "react": "^19.0.0",
-    "react-dom": "^19.0.0"
+    "react-dom": "^19.0.0",
+    "viem": "^2.48.11"
   },
   "devDependencies": {
     "@playwright/test": "^1.59.1",

--- a/packages/frontend/src/components/auction-action-console.tsx
+++ b/packages/frontend/src/components/auction-action-console.tsx
@@ -46,14 +46,14 @@ type AuctionActionConsoleProps = {
 const escrowStages: StageDefinition[] = [
   { label: "Signature lane", note: "User signs a payable lockEscrow request." },
   { label: "Submission", note: "The escrow transaction is sent toward the Sepolia mempool." },
-  { label: "Confirmation", note: "The escrow balance becomes available for prototype sealed bidding." }
+  { label: "Confirmation", note: "The escrow balance becomes available for the next bid action." }
 ];
 
 const bidStages: StageDefinition[] = [
-  { label: "Client sealing", note: "Bid value is packaged into a prototype bid envelope." },
-  { label: "Signature lane", note: "User approves placeBid for the prototype payload." },
-  { label: "Submission", note: "The prototype bid reaches the contract surface." },
-  { label: "Stored", note: "The prototype bid lane is recorded and waits for settlement." }
+  { label: "Client sealing", note: "Bid value is sealed into a bid handle before submission." },
+  { label: "Signature lane", note: "User approves placeBid for the prepared bid handle." },
+  { label: "Submission", note: "The encrypted bid reaches the contract surface." },
+  { label: "Stored", note: "The bid lane is recorded and waits for settlement." }
 ];
 
 function buildStages(definitions: StageDefinition[], activeIndex: number | null, completed = false): ActionStage[] {
@@ -129,7 +129,7 @@ function getPostureMessage(state: AuctionState, isLiveAuction: boolean, closeWin
       }
 
       return isLiveAuction
-        ? "This lot is open for real on-chain escrow locking and prototype sealed bidding right now."
+        ? "This lot is open for real on-chain escrow locking and CoFHE-encrypted bidding right now."
         : "This lot is open for escrow staging and prototype sealed bidding.";
   }
 }
@@ -154,7 +154,7 @@ export function AuctionActionConsole({
   const [isRefreshingWalletEscrow, setIsRefreshingWalletEscrow] = useState(false);
   const [isRunning, setIsRunning] = useState(false);
   const [headline, setHeadline] = useState("Choose your next action");
-  const [note, setNote] = useState("Connect on Sepolia, add escrow, then continue to a prototype sealed bid.");
+  const [note, setNote] = useState("Connect on Sepolia, add escrow, then continue to an encrypted bid.");
   const [notice, setNotice] = useState<string | null>(null);
   const [lastReceipt, setLastReceipt] = useState<string | null>(null);
   const [stages, setStages] = useState<ActionStage[]>(buildStages(escrowStages, null));
@@ -228,14 +228,14 @@ export function AuctionActionConsole({
 
     startTransition(() => {
       setMode(nextMode);
-      setHeadline(nextMode === "escrow" ? "Add escrow first" : "Seal a prototype bid");
+      setHeadline(nextMode === "escrow" ? "Add escrow first" : "Seal an encrypted bid");
       setNote(
         nextMode === "escrow"
           ? isLiveAuction
             ? "Lock real escrow on chain before expecting seller cancellation or refund logic to see it."
             : "Escrow must be added before prototype sealed bidding can open for this lot."
           : isLiveAuction
-            ? "The escrow lane is live on chain. Once your wallet escrow covers the amount, you can submit the prototype bid directly from here."
+            ? "The escrow lane is live on chain. Once your wallet escrow covers the amount, you can submit a CoFHE-encrypted bid directly from here."
             : "A prototype bid becomes available after you have enough escrow in place."
       );
       setNotice(null);
@@ -337,7 +337,7 @@ export function AuctionActionConsole({
       setStages(buildStages(escrowStages, null, true));
       setStagedEscrow((current) => current + amount);
       setHeadline("Escrow added");
-      setNote("You can now continue to the prototype bid step for this lot.");
+      setNote("You can now continue to the next bid step for this lot.");
       setLastReceipt(`Escrow prepared for ${formatEth(amount)} on ${auctionTitle}.`);
       startTransition(() => {
         setMode("bid");
@@ -370,7 +370,7 @@ export function AuctionActionConsole({
 
       const amountWei = parseEther(bidInput);
       if (availableWalletEscrowWei === 0n) {
-        setNotice("Lock escrow first before submitting a prototype bid.");
+        setNotice("Lock escrow first before submitting an encrypted bid.");
         return;
       }
       if (amountWei > availableWalletEscrowWei) {
@@ -380,8 +380,8 @@ export function AuctionActionConsole({
 
       setIsRunning(true);
       setNotice(null);
-      setHeadline("Submitting prototype bid");
-      setNote("Preparing the prototype bid envelope and waiting for the on-chain confirmation trail.");
+      setHeadline("Submitting encrypted bid");
+      setNote("Preparing the CoFHE bid handle and waiting for the on-chain confirmation trail.");
       setLastReceipt(null);
 
       try {
@@ -406,13 +406,13 @@ export function AuctionActionConsole({
         });
 
         setStages(buildStages(bidStages, null, true));
-        setHeadline("Prototype bid stored");
-        setNote("The prototype bid handle is now recorded on chain and will only matter again once settlement starts.");
-        setLastReceipt(`Prototype bid submitted for ${formatEth(amount)} on ${auctionTitle}.`);
+        setHeadline("Encrypted bid stored");
+        setNote("The CoFHE bid handle is now recorded on chain and will only matter again once settlement starts.");
+        setLastReceipt(`Encrypted bid submitted for ${formatEth(amount)} on ${auctionTitle}.`);
         setWalletEscrowWei(result.walletEscrowWei);
         router.refresh();
       } catch (error) {
-        setNotice(error instanceof Error ? error.message : "Prototype bid submission failed.");
+        setNotice(error instanceof Error ? error.message : "Encrypted bid submission failed.");
         resetStageRail("bid");
       } finally {
         setIsRunning(false);
@@ -464,7 +464,7 @@ export function AuctionActionConsole({
         ? "Lock escrow on chain"
         : "Add escrow"
       : isLiveAuction
-        ? "Place prototype bid"
+        ? "Place encrypted bid"
         : "Seal bid";
 
   return (
@@ -472,7 +472,7 @@ export function AuctionActionConsole({
       <div className="section-header">
         <div>
           <p className="eyebrow">Actions</p>
-          <h2 className="section-title">Escrow first. Prototype bid second.</h2>
+          <h2 className="section-title">Escrow first. Encrypted bid second.</h2>
         </div>
       </div>
 
@@ -493,7 +493,7 @@ export function AuctionActionConsole({
               onClick={() => handleSwitchMode("bid")}
               type="button"
             >
-              Prototype Bid
+              {isLiveAuction ? "Encrypted Bid" : "Prototype Bid"}
             </button>
           </div>
 
@@ -528,7 +528,7 @@ export function AuctionActionConsole({
               />
               <p className="detail-copy">
                 {!wallet.hasProvider
-                  ? "An injected wallet is required before the prototype action lane can open."
+                  ? "An injected wallet is required before the bidding action lane can open."
                   : !wallet.isConnected
                     ? "Connect a wallet first before continuing."
                     : "This action is currently available on Sepolia."}
@@ -596,7 +596,7 @@ export function AuctionActionConsole({
                   </div>
                   <p className="action-console__hint">
                     {isLiveAuction
-                      ? "This button submits a prototype on-chain bid handle. Make sure this wallet already locked enough escrow first."
+                      ? "This button submits a CoFHE-derived on-chain bid handle. Make sure this wallet already locked enough escrow first."
                       : `${bidLaneLabel}. Add enough escrow first, then seal the bid amount you want to submit.`}
                   </p>
                   <button

--- a/packages/frontend/src/lib/cofhe-client.ts
+++ b/packages/frontend/src/lib/cofhe-client.ts
@@ -1,0 +1,66 @@
+import { EncryptStep, Encryptable, type EncryptedItemInput } from "@cofhe/sdk";
+import { Ethers6Adapter } from "@cofhe/sdk/adapters";
+import { chains } from "@cofhe/sdk/chains";
+import { createCofheClient, createCofheConfig } from "@cofhe/sdk/web";
+import { BrowserProvider } from "ethers";
+
+import type { Eip1193Provider } from "@/lib/eip1193";
+
+const cofheConfig = createCofheConfig({
+  supportedChains: [chains.sepolia],
+  useWorkers: true
+});
+
+const cofheClient = createCofheClient(cofheConfig);
+
+export type CofheCiphertextInput = Pick<EncryptedItemInput, "ctHash" | "securityZone" | "signature" | "utype">;
+
+type EncryptBidAmountParams = {
+  account: string;
+  amountWei: bigint;
+  chainId: number;
+  onProgress?: (message: string) => void;
+  provider: Eip1193Provider;
+};
+
+function formatEncryptStep(step: EncryptStep, isStart: boolean) {
+  switch (step) {
+    case EncryptStep.InitTfhe:
+      return isStart ? "Initializing the CoFHE runtime..." : "CoFHE runtime ready.";
+    case EncryptStep.FetchKeys:
+      return isStart ? "Fetching CoFHE public keys..." : "CoFHE public keys loaded.";
+    case EncryptStep.Pack:
+      return isStart ? "Packing the bid value into the encrypted input..." : "Encrypted bid input packed.";
+    case EncryptStep.Prove:
+      return isStart ? "Generating the zero-knowledge proof for the bid input..." : "Bid proof generated.";
+    case EncryptStep.Verify:
+      return isStart ? "Verifying the encrypted bid package..." : "Encrypted bid package verified.";
+    default:
+      return isStart ? "Preparing the CoFHE bid package..." : "CoFHE bid package ready.";
+  }
+}
+
+export async function encryptBidAmountWithCofhe({
+  account,
+  amountWei,
+  chainId,
+  onProgress,
+  provider
+}: EncryptBidAmountParams): Promise<CofheCiphertextInput> {
+  const browserProvider = new BrowserProvider(provider);
+  const signer = await browserProvider.getSigner(account);
+  const { publicClient, walletClient } = await Ethers6Adapter(browserProvider, signer);
+
+  await cofheClient.connect(publicClient, walletClient);
+
+  const [encryptedBidInput] = await cofheClient
+    .encryptInputs([Encryptable.uint128(amountWei)])
+    .setAccount(account)
+    .setChainId(chainId)
+    .onStep((step, context) => {
+      onProgress?.(formatEncryptStep(step, context?.isStart ?? true));
+    })
+    .execute();
+
+  return encryptedBidInput;
+}

--- a/packages/frontend/src/lib/live-auction-actions.ts
+++ b/packages/frontend/src/lib/live-auction-actions.ts
@@ -1,5 +1,6 @@
-import { Interface, formatEther, getAddress } from "ethers";
+import { Interface, formatEther, getAddress, toBeHex } from "ethers";
 
+import { encryptBidAmountWithCofhe } from "@/lib/cofhe-client";
 import type { Eip1193Provider } from "@/lib/eip1193";
 
 const marketInterface = new Interface([
@@ -13,8 +14,9 @@ const CIPHERTEXT_KIND_SHIFT = 248n;
 const EUINT96_KIND = 3n;
 const MAX_EUINT96_VALUE = (1n << 96n) - 1n;
 const LOCAL_PROTOTYPE_CHAIN_IDS = new Set(["0x539", "0x7a69"]);
-const PROTOTYPE_BID_DISABLED_MESSAGE =
-  "Prototype wallet bidding is disabled on this network until real CoFHE ciphertext-input support is wired into the frontend.";
+const LIVE_COFHE_CHAIN_ID = "0xaa36a7";
+const UNSUPPORTED_BID_NETWORK_MESSAGE =
+  "Wallet bidding is currently available on Sepolia or local prototype chains only.";
 
 type JsonRpcReceipt = {
   status?: string;
@@ -151,13 +153,8 @@ async function waitForReceipt(provider: Eip1193Provider, txHash: string, timeout
   throw new Error("Transaction confirmation timed out.");
 }
 
-async function assertPrototypeBidPathAllowed(provider: Eip1193Provider) {
-  const chainId = await readChainId(provider);
-  if (LOCAL_PROTOTYPE_CHAIN_IDS.has(chainId)) {
-    return;
-  }
-
-  throw new Error(PROTOTYPE_BID_DISABLED_MESSAGE);
+function isLocalPrototypeChain(chainId: string) {
+  return LOCAL_PROTOTYPE_CHAIN_IDS.has(chainId);
 }
 
 async function readEncryptedBidWithWallet(
@@ -257,10 +254,29 @@ export async function placeBidWithWallet({
   const normalizedMarketAddress = getAddress(marketAddress);
 
   try {
-    await assertPrototypeBidPathAllowed(provider);
+    const chainId = await readChainId(provider);
+    const localPrototypePath = isLocalPrototypeChain(chainId);
+    let encryptedBid: string;
 
-    const encryptedBid = encodeLocalPrototypeEuint96(amountWei);
-    onProgress?.("Preparing the local prototype bid envelope...");
+    if (localPrototypePath) {
+      encryptedBid = encodeLocalPrototypeEuint96(amountWei);
+      onProgress?.("Preparing the local prototype bid envelope...");
+    } else {
+      if (chainId !== LIVE_COFHE_CHAIN_ID) {
+        throw new Error(UNSUPPORTED_BID_NETWORK_MESSAGE);
+      }
+
+      onProgress?.("Preparing the CoFHE-encrypted bid input...");
+      const encryptedBidInput = await encryptBidAmountWithCofhe({
+        account: normalizedAccount,
+        amountWei,
+        chainId: Number.parseInt(chainId, 16),
+        onProgress,
+        provider
+      });
+      encryptedBid = toBeHex(BigInt(encryptedBidInput.ctHash), 32);
+    }
+
     onProgress?.("Confirm the bid transaction in your wallet...");
     const txHash = await sendTransaction(provider, {
       from: normalizedAccount,
@@ -280,10 +296,14 @@ export async function placeBidWithWallet({
     ]);
 
     if (storedBid.toLowerCase() !== encryptedBid.toLowerCase()) {
-      throw new Error("The prototype bid handle was not stored on chain as expected.");
+      throw new Error(
+        localPrototypePath
+          ? "The prototype bid handle was not stored on chain as expected."
+          : "The CoFHE bid handle was not stored on chain as expected."
+      );
     }
 
-    onProgress?.("Local prototype bid handle stored on chain.");
+    onProgress?.(localPrototypePath ? "Local prototype bid handle stored on chain." : "CoFHE bid handle stored on chain.");
     return {
       encryptedBid,
       txHash,

--- a/packages/keeper/services/cofheDispatcher.ts
+++ b/packages/keeper/services/cofheDispatcher.ts
@@ -183,34 +183,8 @@ export class HttpFheosBatchClient implements FheosBatchClient {
       }
 
       const payload = (await response.json()) as Array<Record<string, unknown>>;
-      return payload.map((entry) => {
-        const requestId = String(entry.requestId ?? "");
-        const winner = entry.winner === null || entry.winner === undefined ? null : String(entry.winner);
-        const matchingJob = jobs.find((job) => job.requestId === requestId);
-        const winningBid = winner === null ? undefined : matchingJob?.bids.find((bid) => bid.bidder === winner);
-
-        return {
-          auctionId: BigInt(String(entry.auctionId ?? "0")),
-          requestId,
-          winnerHandle: String(entry.winnerHandle ?? ""),
-          amountHandle: String(entry.amountHandle ?? ""),
-          winner,
-          winnerKind:
-            entry.winnerKind === "shielded"
-              ? "shielded"
-              : entry.winnerKind === "none"
-                ? "none"
-                : winningBid?.isShielded
-                  ? "shielded"
-                  : winner === null
-                    ? "none"
-                    : "public",
-          winnerCiphertext: String(entry.winnerCiphertext ?? ZERO_HASH),
-          winningAmount: BigInt(String(entry.winningAmount ?? "0")),
-          latencyMs: Number(entry.latencyMs ?? 0),
-          avsProof: String(entry.avsProof ?? "")
-        };
-      });
+      const jobsByRequestId = new Map(jobs.map((job) => [job.requestId, job]));
+      return payload.map((entry) => parseLiveResolutionEntry(entry, jobsByRequestId));
     } finally {
       clearTimeout(timeout);
     }
@@ -345,6 +319,85 @@ export function pickHighestLocalPrototypeEncryptedBid(
 
 function buildSyntheticAvsProof(requestId: string, winnerCiphertext: string): string {
   return `proof:${requestId}:${winnerCiphertext}`;
+}
+
+function parseLiveResolutionEntry(
+  entry: Record<string, unknown>,
+  jobsByRequestId: ReadonlyMap<string, CoFheDispatchJob>
+): CoFheResolution {
+  const requestId = String(entry.requestId ?? "");
+  const matchingJob = jobsByRequestId.get(requestId);
+  if (!matchingJob) {
+    throw new Error(`Live CoFHE response referenced an unknown requestId: ${requestId}`);
+  }
+
+  const winnerKind = normalizeWinnerKind(entry.winnerKind);
+  const winnerHandle = String(entry.winnerHandle ?? "");
+  const amountHandle = String(entry.amountHandle ?? "");
+  const latencyMs = Number(entry.latencyMs ?? 0);
+  const avsProof = String(entry.avsProof ?? "");
+
+  if (winnerHandle.trim() === "" || amountHandle.trim() === "" || avsProof.trim() === "") {
+    throw new Error(`Live CoFHE response for ${requestId} is missing required handles or proof material`);
+  }
+
+  if (winnerKind === "none") {
+    const winner = entry.winner === null || entry.winner === undefined ? null : String(entry.winner);
+    const winnerCiphertext = String(entry.winnerCiphertext ?? ZERO_HASH);
+    const winningAmount = BigInt(String(entry.winningAmount ?? "0"));
+    if (winner !== null || winnerCiphertext !== ZERO_HASH || winningAmount !== 0n) {
+      throw new Error(`Live CoFHE response for ${requestId} returned an invalid no-winner resolution`);
+    }
+
+    return {
+      auctionId: matchingJob.auctionId,
+      requestId,
+      winnerHandle,
+      amountHandle,
+      winner: null,
+      winnerKind,
+      winnerCiphertext,
+      winningAmount,
+      latencyMs,
+      avsProof
+    };
+  }
+
+  const winner = String(entry.winner ?? "");
+  const winnerCiphertext = String(entry.winnerCiphertext ?? "");
+  const winningAmount = BigInt(String(entry.winningAmount ?? "0"));
+  if (winner.trim() === "" || winnerCiphertext.trim() === "" || winningAmount <= 0n) {
+    throw new Error(`Live CoFHE response for ${requestId} is missing explicit winner metadata`);
+  }
+
+  const matchingBid = matchingJob.bids.find((bid) => bid.bidder === winner && Boolean(bid.isShielded) === (winnerKind === "shielded"));
+  if (!matchingBid) {
+    throw new Error(`Live CoFHE response for ${requestId} referenced a winner outside the submitted bid set`);
+  }
+  if (matchingBid.encryptedBid !== winnerCiphertext) {
+    throw new Error(`Live CoFHE response for ${requestId} returned a ciphertext that does not match the submitted winner bid`);
+  }
+
+  return {
+    auctionId: matchingJob.auctionId,
+    requestId,
+    winnerHandle,
+    amountHandle,
+    winner,
+    winnerKind,
+    winnerCiphertext,
+    winningAmount,
+    latencyMs,
+    avsProof
+  };
+}
+
+function normalizeWinnerKind(value: unknown): "public" | "shielded" | "none" {
+  if (value === "public" || value === "shielded" || value === "none") {
+    return value;
+  }
+
+  throw new Error(`Live CoFHE response returned an unsupported winnerKind: ${String(value ?? "")}`);
 }
 
 function normalizeError(error: unknown): Error {

--- a/packages/keeper/test/keeper.test.ts
+++ b/packages/keeper/test/keeper.test.ts
@@ -14,6 +14,7 @@ import {
 import { AvsSubmitter, aggregateSignatures, validateFraudProof } from "../services/avsSubmitter";
 import {
   CofheDispatcher,
+  HttpFheosBatchClient,
   InMemoryDispatchQueue,
   LocalCofheBatchClient,
   createFheosBatchClient,
@@ -228,6 +229,67 @@ async function main(): Promise<void> {
 
     assert.equal(resolution.winner, "0x00000000000000000000000000000000000000aa");
     assert.equal(resolution.winningAmount, 100n);
+  });
+
+  await runCase("cofhe dispatcher trusts explicit live provider results instead of local bid ranking", async () => {
+    const dispatcher = new CofheDispatcher(
+      new InMemoryDispatchQueue(),
+      () => 2_750,
+      undefined,
+      {
+        resolveBatch: async (jobs) =>
+          jobs.map((job) => ({
+            auctionId: job.auctionId,
+            requestId: job.requestId,
+            winnerHandle: job.winnerHandle,
+            amountHandle: job.amountHandle,
+            winner: "0x00000000000000000000000000000000000000bb",
+            winnerKind: "public" as const,
+            winnerCiphertext: job.bids[1].encryptedBid,
+            winningAmount: 99n,
+            latencyMs: 12,
+            avsProof: "proof:live-provider"
+          }))
+      }
+    );
+
+    const resolution = await dispatcher.dispatch(buildJob(11n, "request-live-provider-authority", 100n));
+    assert.equal(resolution.winner, "0x00000000000000000000000000000000000000bb");
+    assert.equal(resolution.winningAmount, 99n);
+    assert.equal(resolution.winnerCiphertext, encodeEncryptedUint32(99n));
+  });
+
+  await runCase("http cofhe client rejects malformed live winner results instead of inferring them locally", async () => {
+    const client = new HttpFheosBatchClient(
+      "https://fheos.example",
+      "secret",
+      async () =>
+        ({
+          ok: true,
+          json: async () => [
+            {
+              auctionId: "12",
+              requestId: "request-malformed-live-result",
+              winnerHandle: "winner-request-malformed-live-result",
+              amountHandle: "amount-request-malformed-live-result",
+              winner: "0x00000000000000000000000000000000000000aa",
+              winnerCiphertext: encodeEncryptedUint32(100n),
+              winningAmount: "100",
+              latencyMs: 7,
+              avsProof: "proof:missing-kind"
+            }
+          ]
+        }) as Response
+    );
+
+    await assert.rejects(
+      () =>
+        client.resolveBatch(
+          [buildJob(12n, "request-malformed-live-result", 100n)],
+          1_000
+        ),
+      /unsupported winnerKind|missing explicit winner metadata/
+    );
   });
 
   await runCase("cofhe dispatcher respects the public opening bid and can yield a no-winner result", async () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,7 +18,7 @@ importers:
         version: 0.3.1(@fhenixprotocol/cofhe-contracts@0.0.13)(@openzeppelin/contracts-upgradeable@5.6.1(@openzeppelin/contracts@5.6.1))(@openzeppelin/contracts@5.6.1)
       '@nomicfoundation/hardhat-toolbox':
         specifier: ^5.0.0
-        version: 5.0.0(cb65419f6d03eab7ca16d431ae77f05b)
+        version: 5.0.0(hmdm5oo6xyx5qnxvbdlhx6hhwq)
       '@openzeppelin/contracts':
         specifier: ^5.0.2
         version: 5.6.1
@@ -58,6 +58,9 @@ importers:
 
   packages/frontend:
     dependencies:
+      '@cofhe/sdk':
+        specifier: ^0.5.2
+        version: 0.5.2(@nomicfoundation/hardhat-ethers@3.1.3(ethers@6.16.0)(hardhat@2.28.6(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.9.3))(typescript@5.9.3)))(@types/react@19.2.14)(ethers@6.16.0)(hardhat@2.28.6(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.9.3))(typescript@5.9.3))(react@19.2.5)(viem@2.48.11(typescript@5.9.3)(zod@4.0.0))
       ethers:
         specifier: ^6.14.0
         version: 6.16.0
@@ -70,6 +73,9 @@ importers:
       react-dom:
         specifier: ^19.0.0
         version: 19.2.5(react@19.2.5)
+      viem:
+        specifier: ^2.48.11
+        version: 2.48.11(typescript@5.9.3)(zod@4.0.0)
     devDependencies:
       '@playwright/test':
         specifier: ^1.59.1
@@ -113,6 +119,27 @@ packages:
 
   '@adraffy/ens-normalize@1.10.1':
     resolution: {integrity: sha512-96Z2IP3mYmF1Xg2cDm8f1gWGf/HUVedQ3FMifV4kG/PQ4yEP51xDtRAEfhVNt5f/uzpNkZHwWQuUcu6D6K+Ekw==}
+
+  '@adraffy/ens-normalize@1.11.1':
+    resolution: {integrity: sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ==}
+
+  '@cofhe/sdk@0.5.2':
+    resolution: {integrity: sha512-OJ1c6GF5CmpumQhWg4GLxx0V+Gyo3N5XcjuAfXzVy5g9PEGq4VpkfvnDBqmwc0K6+m9kff29Jtw/KfUE5v+xQw==}
+    peerDependencies:
+      '@nomicfoundation/hardhat-ethers': ^3.0.0
+      '@wagmi/core': ^2.0.0
+      ethers: ^5.0.0 || ^6.0.0
+      hardhat: ^2.0.0
+      viem: ^2.38.6
+    peerDependenciesMeta:
+      '@nomicfoundation/hardhat-ethers':
+        optional: true
+      '@wagmi/core':
+        optional: true
+      ethers:
+        optional: true
+      hardhat:
+        optional: true
 
   '@cspotcode/source-map-support@0.8.1':
     resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
@@ -450,6 +477,10 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@noble/ciphers@1.3.0':
+    resolution: {integrity: sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==}
+    engines: {node: ^14.21.3 || >=16}
+
   '@noble/curves@1.2.0':
     resolution: {integrity: sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw==}
 
@@ -458,6 +489,10 @@ packages:
 
   '@noble/curves@1.8.2':
     resolution: {integrity: sha512-vnI7V6lFNe0tLAuJMu+2sX+FcL14TaCWy1qiczg1VwRmPrpQCdq5ESXQMqUc2tluRNf6irBXrWbl1mGN8uaU/g==}
+    engines: {node: ^14.21.3 || >=16}
+
+  '@noble/curves@1.9.1':
+    resolution: {integrity: sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA==}
     engines: {node: ^14.21.3 || >=16}
 
   '@noble/hashes@1.2.0':
@@ -650,11 +685,17 @@ packages:
   '@scure/bip32@1.4.0':
     resolution: {integrity: sha512-sVUpc0Vq3tXCkDGYVWGIZTRfnvu8LoTDaev7vbwh0omSvVORONr960MQWdKqJDCReIEmTj3PAr73O3aoxz7OPg==}
 
+  '@scure/bip32@1.7.0':
+    resolution: {integrity: sha512-E4FFX/N3f4B80AKWp5dP6ow+flD1LQZo/w8UnLGYZO674jS6YnYeepycOOksv+vLPSpgN35wgKgy+ybfTb2SMw==}
+
   '@scure/bip39@1.1.1':
     resolution: {integrity: sha512-t+wDck2rVkh65Hmv280fYdVdY25J9YeEUIgn2LG1WM6gxFkGzcksoDiUkWVpVp3Oex9xGC68JU2dSbUfwZ2jPg==}
 
   '@scure/bip39@1.3.0':
     resolution: {integrity: sha512-disdg7gHuTDZtY+ZdkmLpPCk7fxZSu3gBiEGuoC1XYxv9cGx3Z6cpTggCgW6odSOOIXCiDjuGejW+aJKCY/pIQ==}
+
+  '@scure/bip39@1.6.0':
+    resolution: {integrity: sha512-+lF0BbLiJNwVlev4eKelw1WWLaiKXw7sSl8T6FvBlWkdX+94aGJ4o8XjUdlyhTCjd8c+B3KT3JfS8P0bLRNU6A==}
 
   '@sentry/core@5.30.0':
     resolution: {integrity: sha512-TmfrII8w1PQZSZgPpUESqjB+jC6MvZJZdLtE/0hZ+SrnKhW3x5WlYLvTXZpcWePYBku7rl2wn1RZu6uT0qCTeg==}
@@ -782,6 +823,17 @@ packages:
 
   abbrev@1.0.9:
     resolution: {integrity: sha512-LEyx4aLEC3x6T0UguF6YILf+ntvmOaWsVfENmIW0E9H09vKlLDGelMjjSm0jkDHALj8A8quZ/HapKNigzwge+Q==}
+
+  abitype@1.2.3:
+    resolution: {integrity: sha512-Ofer5QUnuUdTFsBRwARMoWKOH1ND5ehwYhJ3OJ/BQO+StkwQjHw0XyVh4vDttzHB7QOFhPHa/o413PJ82gU/Tg==}
+    peerDependencies:
+      typescript: '>=5.0.4'
+      zod: ^3.22.0 || ^4.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+      zod:
+        optional: true
 
   acorn-walk@8.3.5:
     resolution: {integrity: sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==}
@@ -1340,6 +1392,9 @@ packages:
     resolution: {integrity: sha512-/Sn9Y0oKl0uqQuvgFk/zQgR7aw1g36qX/jzSQ5lSwlO0GigPymk4eGQfeNTD03w1dPOqfz8V77Cy43jH56pagw==}
     engines: {node: '>=6.5.0', npm: '>=3'}
 
+  eventemitter3@5.0.1:
+    resolution: {integrity: sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==}
+
   evp_bytestokey@1.0.3:
     resolution: {integrity: sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==}
 
@@ -1610,12 +1665,18 @@ packages:
   idb-keyval@6.2.2:
     resolution: {integrity: sha512-yjD9nARJ/jb1g+CvD0tlhUHOrJ9Sy0P8T9MF3YaLlHnSRpwPfpTX0XIvpmw3gAJUmEu3FiICLBDPXVwyEvrleg==}
 
+  iframe-shared-storage@1.0.34:
+    resolution: {integrity: sha512-sb80NhdVgVNhkc72pTyAjcaHQNiIPeu314zFtXbQaTjp9OOnaZ5+IjS/ylNXs08kwvlmBpg7GG5GOWzjRMP9Ww==}
+
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
     engines: {node: '>= 4'}
 
   immer@10.0.2:
     resolution: {integrity: sha512-Rx3CqeqQ19sxUtYV9CU911Vhy8/721wRFnJv3REVGWUmoAcIwzifTsdmJte/MV+0/XpM35LZdQMBGkRIoLPwQA==}
+
+  immer@10.1.1:
+    resolution: {integrity: sha512-s2MPrmjovJcoMaHtx6K11Ra7oD05NT97w1IC5zpMkT6Atjr7H8LjaDd81iIxUYpMKSRRNMJE703M1Fhr/TctHw==}
 
   immer@10.2.0:
     resolution: {integrity: sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==}
@@ -1700,6 +1761,11 @@ packages:
 
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+
+  isows@1.0.7:
+    resolution: {integrity: sha512-I1fSfDCZL5P0v33sVqeTDSpcstAg/N+wF5HS033mogOVIp4B+oHC7oOCsA3axAbBSGTJ8QubbNmnIRN/h8U7hg==}
+    peerDependencies:
+      ws: '*'
 
   jake@10.9.4:
     resolution: {integrity: sha512-wpHYzhxiVQL+IV05BLE2Xn34zW1S223hvjtqk0+gsPrwd/8JNLXJgZZM/iPFsYc1xyphF+6M6EvdE5E9MBGkDA==}
@@ -1928,6 +1994,9 @@ packages:
   node-tfhe@0.11.1:
     resolution: {integrity: sha512-QFkIeIZ5IbdvhpkzImwakL2+sZFCTXCwGvOacE1NczR+zgrg5ixHU9KpjuuIi1YbbKFGJEMoSUmivDktuzFaKg==}
 
+  node-tfhe@1.5.3:
+    resolution: {integrity: sha512-VjCx9vaNbTkw8I0IeMvmHPUOfjiXysbQXc9C4LKx4V8GmPNKufL6fAaDyFWWeAuHa/xs/AaWlTQ3jkTlFL4K+w==}
+
   nofilter@3.1.0:
     resolution: {integrity: sha512-l2NNj07e9afPnhAhvgVrCD/oy2Ai1yfLpuo3EpiO1jFTsB4sFz6oIfAfSZyQzVpkZQ9xS8ZS5g1jCBgq4Hwo0g==}
     engines: {node: '>=12.19'}
@@ -1968,6 +2037,14 @@ packages:
   os-tmpdir@1.0.2:
     resolution: {integrity: sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==}
     engines: {node: '>=0.10.0'}
+
+  ox@0.14.20:
+    resolution: {integrity: sha512-rby38C3nDn8eQkf29Zgw4hkCZJ64Qqi0zRPWL8ENUQ7JVuoITqrVtwWQgM/He19SCMUEc7hS/Sjw0jIOSLJhOw==}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
   p-limit@3.1.0:
     resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
@@ -2038,6 +2115,9 @@ packages:
   postcss@8.4.31:
     resolution: {integrity: sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==}
     engines: {node: ^10 || ^12 || >=14}
+
+  postmsg-rpc@2.4.0:
+    resolution: {integrity: sha512-adGH2zGSxhCUOfUfAXdRn4tgZVWauaSP2X8on+g7uBA45sxkzORL1oia95eXZtcZk5Sp4JTZmDFOTe+D24avBQ==}
 
   prelude-ls@1.1.2:
     resolution: {integrity: sha512-ESF23V4SKG6lVSGZgYNpbsiaAkdab6ZgOxe52p7+Kid3W3u3bxR4Vfd/o21dmN7jSt0IwgZ4v5MUd26FEtXE9w==}
@@ -2227,6 +2307,9 @@ packages:
     engines: {node: '>=4'}
     hasBin: true
 
+  shortid@2.2.17:
+    resolution: {integrity: sha512-GpbM3gLF1UUXZvQw6MCyulHkWbRseNO4cyBEZresZRorwl1+SLu1ZdqgVtuwqz8mB6RpwPkm541mYSqrKyJSaA==}
+
   side-channel-list@1.0.1:
     resolution: {integrity: sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==}
     engines: {node: '>= 0.4'}
@@ -2384,6 +2467,9 @@ packages:
 
   tfhe@0.11.1:
     resolution: {integrity: sha512-D4YeL0DYz4IOV/X7YzKFexkjbJdOdGn2M7mfDNOQW1OxA+NO/Z61BJ6ULLTvdBEQ3N6P985lNO61Drgsjf0g/w==}
+
+  tfhe@1.5.3:
+    resolution: {integrity: sha512-Geyw5g1TeHFqNGWYiXZmmfRl1wFml3Jkmo9mHor3nPSIr6V6LJRLILceqKdvOW2ieqxB662gwmm2Qo4SUji2tA==}
 
   then-request@6.0.2:
     resolution: {integrity: sha512-3ZBiG7JvP3wbDzA9iNY5zJQcHL4jn/0BWtXIkagfz7QgOL/LqjCEOBQuJNZfu0XYnv5JhKh+cDxCPM4ILrqruA==}
@@ -2544,10 +2630,19 @@ packages:
 
   uuid@8.3.2:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   v8-compile-cache-lib@3.0.1:
     resolution: {integrity: sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==}
+
+  viem@2.48.11:
+    resolution: {integrity: sha512-+WZ5E0dBS6GtKb+1wEk5DeYRRRW42+pFnXCo67Ydodf42sBwO+hu3wnQy66lc4MKmHz+llPVdbyehYr9oTE2iw==}
+    peerDependencies:
+      typescript: '>=5.0.4'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
   wasmbuilder@0.0.16:
     resolution: {integrity: sha512-Qx3lEFqaVvp1cEYW7Bfi+ebRJrOiwz2Ieu7ZG2l7YyeSJIok/reEQCQCuicj/Y32ITIJuGIM9xZQppGx5LrQdA==}
@@ -2631,6 +2726,18 @@ packages:
       utf-8-validate:
         optional: true
 
+  ws@8.18.3:
+    resolution: {integrity: sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
   y18n@5.0.8:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
     engines: {node: '>=10'}
@@ -2658,6 +2765,27 @@ packages:
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
+  zod@4.0.0:
+    resolution: {integrity: sha512-9diLdTPc/L7w/5jI4C3gHYNiGHDV9IZYxo1e5LSD8cabi65WVTWWb+g2BGPEpUUCOxR4D+6O5B0AzyMdUAXwrw==}
+
+  zustand@5.0.1:
+    resolution: {integrity: sha512-pRET7Lao2z+n5R/HduXMio35TncTlSW68WsYBq2Lg1ASspsNGjpwLAsij3RpouyV6+kHMwwwzP0bZPD70/Jx/w==}
+    engines: {node: '>=12.20.0'}
+    peerDependencies:
+      '@types/react': '>=18.0.0'
+      immer: '>=9.0.6'
+      react: '>=18.0.0'
+      use-sync-external-store: '>=1.2.0'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      immer:
+        optional: true
+      react:
+        optional: true
+      use-sync-external-store:
+        optional: true
+
   zustand@5.0.12:
     resolution: {integrity: sha512-i77ae3aZq4dhMlRhJVCYgMLKuSiZAaUPAct2AksxQ+gOtimhGMdXljRT21P5BNpeT4kXlLIckvkPM029OljD7g==}
     engines: {node: '>=12.20.0'}
@@ -2679,6 +2807,27 @@ packages:
 snapshots:
 
   '@adraffy/ens-normalize@1.10.1': {}
+
+  '@adraffy/ens-normalize@1.11.1': {}
+
+  '@cofhe/sdk@0.5.2(@nomicfoundation/hardhat-ethers@3.1.3(ethers@6.16.0)(hardhat@2.28.6(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.9.3))(typescript@5.9.3)))(@types/react@19.2.14)(ethers@6.16.0)(hardhat@2.28.6(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.9.3))(typescript@5.9.3))(react@19.2.5)(viem@2.48.11(typescript@5.9.3)(zod@4.0.0))':
+    dependencies:
+      iframe-shared-storage: 1.0.34
+      immer: 10.1.1
+      node-tfhe: 1.5.3
+      tfhe: 1.5.3
+      tweetnacl: 1.0.3
+      viem: 2.48.11(typescript@5.9.3)(zod@4.0.0)
+      zod: 4.0.0
+      zustand: 5.0.1(@types/react@19.2.14)(immer@10.1.1)(react@19.2.5)
+    optionalDependencies:
+      '@nomicfoundation/hardhat-ethers': 3.1.3(ethers@6.16.0)(hardhat@2.28.6(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.9.3))(typescript@5.9.3))
+      ethers: 6.16.0
+      hardhat: 2.28.6(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.9.3))(typescript@5.9.3)
+    transitivePeerDependencies:
+      - '@types/react'
+      - react
+      - use-sync-external-store
 
   '@cspotcode/source-map-support@0.8.1':
     dependencies:
@@ -3118,6 +3267,8 @@ snapshots:
   '@next/swc-win32-x64-msvc@15.5.15':
     optional: true
 
+  '@noble/ciphers@1.3.0': {}
+
   '@noble/curves@1.2.0':
     dependencies:
       '@noble/hashes': 1.3.2
@@ -3129,6 +3280,10 @@ snapshots:
   '@noble/curves@1.8.2':
     dependencies:
       '@noble/hashes': 1.7.2
+
+  '@noble/curves@1.9.1':
+    dependencies:
+      '@noble/hashes': 1.8.0
 
   '@noble/hashes@1.2.0': {}
 
@@ -3227,7 +3382,7 @@ snapshots:
       ethereumjs-util: 7.1.5
       hardhat: 2.28.6(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.9.3))(typescript@5.9.3)
 
-  '@nomicfoundation/hardhat-toolbox@5.0.0(cb65419f6d03eab7ca16d431ae77f05b)':
+  '@nomicfoundation/hardhat-toolbox@5.0.0(hmdm5oo6xyx5qnxvbdlhx6hhwq)':
     dependencies:
       '@nomicfoundation/hardhat-chai-matchers': 2.1.2(@nomicfoundation/hardhat-ethers@3.1.3(ethers@6.16.0)(hardhat@2.28.6(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.9.3))(typescript@5.9.3)))(chai@4.5.0)(ethers@6.16.0)(hardhat@2.28.6(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.9.3))(typescript@5.9.3))
       '@nomicfoundation/hardhat-ethers': 3.1.3(ethers@6.16.0)(hardhat@2.28.6(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.9.3))(typescript@5.9.3))
@@ -3338,6 +3493,12 @@ snapshots:
       '@noble/hashes': 1.4.0
       '@scure/base': 1.1.9
 
+  '@scure/bip32@1.7.0':
+    dependencies:
+      '@noble/curves': 1.9.1
+      '@noble/hashes': 1.8.0
+      '@scure/base': 1.2.6
+
   '@scure/bip39@1.1.1':
     dependencies:
       '@noble/hashes': 1.2.0
@@ -3347,6 +3508,11 @@ snapshots:
     dependencies:
       '@noble/hashes': 1.4.0
       '@scure/base': 1.1.9
+
+  '@scure/bip39@1.6.0':
+    dependencies:
+      '@noble/hashes': 1.8.0
+      '@scure/base': 1.2.6
 
   '@sentry/core@5.30.0':
     dependencies:
@@ -3497,6 +3663,11 @@ snapshots:
       '@types/node': 22.19.17
 
   abbrev@1.0.9: {}
+
+  abitype@1.2.3(typescript@5.9.3)(zod@4.0.0):
+    optionalDependencies:
+      typescript: 5.9.3
+      zod: 4.0.0
 
   acorn-walk@8.3.5:
     dependencies:
@@ -4148,6 +4319,8 @@ snapshots:
       bn.js: 4.11.6
       number-to-bn: 1.7.0
 
+  eventemitter3@5.0.1: {}
+
   evp_bytestokey@1.0.3:
     dependencies:
       md5.js: 1.3.5
@@ -4510,9 +4683,16 @@ snapshots:
 
   idb-keyval@6.2.2: {}
 
+  iframe-shared-storage@1.0.34:
+    dependencies:
+      idb-keyval: 6.2.2
+      postmsg-rpc: 2.4.0
+
   ignore@5.3.2: {}
 
   immer@10.0.2: {}
+
+  immer@10.1.1: {}
 
   immer@10.2.0: {}
 
@@ -4572,6 +4752,10 @@ snapshots:
   isarray@2.0.5: {}
 
   isexe@2.0.0: {}
+
+  isows@1.0.7(ws@8.18.3):
+    dependencies:
+      ws: 8.18.3
 
   jake@10.9.4:
     dependencies:
@@ -4800,6 +4984,8 @@ snapshots:
 
   node-tfhe@0.11.1: {}
 
+  node-tfhe@1.5.3: {}
+
   nofilter@3.1.0: {}
 
   nopt@3.0.6:
@@ -4835,6 +5021,21 @@ snapshots:
   ordinal@1.0.3: {}
 
   os-tmpdir@1.0.2: {}
+
+  ox@0.14.20(typescript@5.9.3)(zod@4.0.0):
+    dependencies:
+      '@adraffy/ens-normalize': 1.11.1
+      '@noble/ciphers': 1.3.0
+      '@noble/curves': 1.9.1
+      '@noble/hashes': 1.8.0
+      '@scure/bip32': 1.7.0
+      '@scure/bip39': 1.6.0
+      abitype: 1.2.3(typescript@5.9.3)(zod@4.0.0)
+      eventemitter3: 5.0.1
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - zod
 
   p-limit@3.1.0:
     dependencies:
@@ -4892,6 +5093,10 @@ snapshots:
       nanoid: 3.3.11
       picocolors: 1.1.1
       source-map-js: 1.2.1
+
+  postmsg-rpc@2.4.0:
+    dependencies:
+      shortid: 2.2.17
 
   prelude-ls@1.1.2: {}
 
@@ -5120,6 +5325,10 @@ snapshots:
       interpret: 1.4.0
       rechoir: 0.6.2
 
+  shortid@2.2.17:
+    dependencies:
+      nanoid: 3.3.11
+
   side-channel-list@1.0.1:
     dependencies:
       es-errors: 1.3.0
@@ -5320,6 +5529,8 @@ snapshots:
 
   tfhe@0.11.1: {}
 
+  tfhe@1.5.3: {}
+
   then-request@6.0.2:
     dependencies:
       '@types/concat-stream': 1.6.1
@@ -5473,6 +5684,23 @@ snapshots:
 
   v8-compile-cache-lib@3.0.1: {}
 
+  viem@2.48.11(typescript@5.9.3)(zod@4.0.0):
+    dependencies:
+      '@noble/curves': 1.9.1
+      '@noble/hashes': 1.8.0
+      '@scure/bip32': 1.7.0
+      '@scure/bip39': 1.6.0
+      abitype: 1.2.3(typescript@5.9.3)(zod@4.0.0)
+      isows: 1.0.7(ws@8.18.3)
+      ox: 0.14.20(typescript@5.9.3)(zod@4.0.0)
+      ws: 8.18.3
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+      - zod
+
   wasmbuilder@0.0.16: {}
 
   wasmcurves@0.2.2:
@@ -5535,6 +5763,8 @@ snapshots:
 
   ws@8.18.0: {}
 
+  ws@8.18.3: {}
+
   y18n@5.0.8: {}
 
   yargs-parser@20.2.9: {}
@@ -5561,6 +5791,14 @@ snapshots:
   yocto-queue@0.1.0: {}
 
   zod@3.25.76: {}
+
+  zod@4.0.0: {}
+
+  zustand@5.0.1(@types/react@19.2.14)(immer@10.1.1)(react@19.2.5):
+    optionalDependencies:
+      '@types/react': 19.2.14
+      immer: 10.1.1
+      react: 19.2.5
 
   zustand@5.0.12(@types/react@19.2.14)(immer@10.2.0)(react@19.2.5):
     optionalDependencies:


### PR DESCRIPTION
## Summary

This PR completes the remaining production-path work for Issue #4 by replacing the live frontend prototype bid path with a real CoFHE SDK flow and tightening the keeper so live winner selection is accepted only from explicit CoFHE/AVS results.

### Included

- integrate CoFHE SDK into the frontend Sepolia bidding path
- replace local `encodeEuint96()` usage on the live frontend path
- keep local prototype bid encoding isolated to local development chains only
- add a dedicated frontend `cofhe-client` helper for encrypted bid input generation
- update auction action copy so live Sepolia flow is described as encrypted CoFHE bidding instead of prototype-only wording
- tighten live keeper resolution parsing so it does not infer winner metadata locally
- require explicit `winnerKind`, winner identity, ciphertext, and proof material from live CoFHE responses
- reject malformed live responses instead of silently falling back to local interpretation
- add keeper regression tests proving live provider output governs winner selection

## Why

Issue #4 still had two important open gaps:

- `#4.4` real CoFHE SDK/provider integration in the frontend
- `#4.7` winner selection from CoFHE/AVS result instead of local comparison

This PR closes those gaps while preserving deterministic local simulation for local-only development and tests.

## Security impact

- Sepolia wallet bidding no longer depends on local reversible prototype ciphertext construction
- live winner resolution is no longer derived from local ranking logic inside the keeper path
- malformed or incomplete live CoFHE responses now fail closed instead of being interpreted optimistically
- local prototype decoding remains available only for explicit local simulation and test flows

## Validation

- `pnpm.cmd --filter frontend build`
- `pnpm.cmd install`
- `pnpm.cmd --filter keeper test`

## Notes

- local prototype behavior is intentionally preserved for local chains and deterministic keeper simulation
- this PR focuses on the live frontend/keeper production path and does not claim that all prototype-only helper code has been removed from local-only tooling
